### PR TITLE
Feature flags service, alternative implementation proposal

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ gem "syslog-logger"
 gem "puma"
 gem "redis"
 gem "ohm"
+gem 'i18n'
 
 gem "newrelic_rpm"
 gem "airbrake"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,6 +12,7 @@ GEM
     foreman (0.63.0)
       dotenv (>= 0.7)
       thor (>= 0.13.6)
+    i18n (0.6.5)
     json (1.8.1)
     method_source (0.8.2)
     minitest (4.7.5)
@@ -265,6 +266,7 @@ PLATFORMS
 DEPENDENCIES
   airbrake
   foreman
+  i18n
   newrelic_rpm
   ohm
   pry

--- a/lib/services/feature_service.rb
+++ b/lib/services/feature_service.rb
@@ -1,0 +1,64 @@
+require 'i18n'
+require 'json'
+
+class FeatureService
+  def initialize(opts={})
+    @redis = opts.fetch(:redis, Redis.new)
+    @ns    = Array(opts.fetch(:ns, 'bandiera'))
+  end
+
+  def groups
+    @redis.smembers(groups_key)
+  end
+
+  def add_group(group)
+    @redis.sadd(groups_key, t(group))
+  end
+
+  def add_feature(group, feature, enabled, description=nil)
+    data = {
+      enabled:     enabled,
+      description: description,
+      flag:        t(feature),
+    }
+    @redis.multi do
+      add_group(group)
+      @redis.sadd(group_features_key(group), t(feature))
+      @redis.set(feature_key(group, feature), data.to_json)
+    end
+  end
+
+  def feature(group, feature_name)
+    val = @redis.get(feature_key(group, feature_name))
+    JSON.parse(val) if val
+  end
+
+  def group_features(group)
+    feature_ids  = @redis.smembers(group_features_key(group))
+    feature_keys = feature_ids.map { |id| feature_key(group, id) }
+    feature_data = @redis.mget(*feature_keys)
+    feature_data.reject(&:nil?).map { |v| JSON.parse(v) }
+  end
+
+  private
+
+  def t(val)
+    I18n.transliterate(val.downcase.strip).gsub(/\s+/,'-')
+  end
+
+  def groups_key
+    key('groups')
+  end
+
+  def feature_key(group, id)
+    key('feature', t(group), t(id))
+  end
+
+  def group_features_key(group)
+    key('groups', t(group), 'features')
+  end
+
+  def key(*args)
+    (@ns + args).join("/")
+  end
+end

--- a/spec/services/feature_service_spec.rb
+++ b/spec/services/feature_service_spec.rb
@@ -1,0 +1,79 @@
+require_relative '../../lib/services/feature_service'
+require 'redis'
+
+describe FeatureService do
+  let(:ns)              { 'bandiera-test' }
+  let(:redis)           { Redis.new }
+  let(:feature_service) {
+    FeatureService.new(redis: redis, ns: ns)
+  }
+
+  before(:each) do
+    keys = redis.keys("#{ns}*")
+    redis.pipelined do
+      keys.each do |k|
+        redis.del(k)
+      end
+    end
+  end
+
+  describe "#add_group" do
+    context "when no groups" do
+      it "#groups should be an empty array" do
+        feature_service.groups.should eq []
+      end
+    end
+
+    context "when some groups are added" do
+      before do
+        feature_service.add_group('Group 1')
+        feature_service.add_group('group 1')
+        feature_service.add_group('GrouP 2')
+      end
+      it "#groups should return unique list of transliterate group names" do
+        feature_service.groups.to_set.should eq ["group-1", "group-2"].to_set
+      end
+    end
+  end
+
+  describe "#add_feature" do
+    before do
+      feature_service.add_feature('test group', 'my feature',true, 'my test description')
+    end
+
+    it "Creates the associated group if it doesn't exist" do
+      feature_service.groups.should eq ['test-group']
+    end
+
+    it "keeps track of the feature flags associated to each group" do
+      feature_service.group_features('test-group').map { |f| f['flag'] }.should eq ['my-feature']
+    end
+
+    it "Saves the feature data" do
+      expected = {
+        'flag'        => 'my-feature',
+        'description' => 'my test description',
+        'enabled'     => true
+      }
+      feature_service.feature('Test Group', 'My Feature').should eq expected
+      feature_service.feature('test-group', 'my-feature').should eq expected
+    end
+  end
+
+  describe "#group_features" do
+    before do
+      [['group A', 'flag 1'],
+       ['group A', 'flag 2'],
+       ['group B', 'flag 1']].each do |(group, feature)|
+         feature_service.add_feature(group, feature, true)
+       end
+    end
+
+    it "returns the feature flags associated to a given group" do
+      features = feature_service.group_features('group a')
+      features.size.should eq 2
+      features.first.should eq({'flag' => 'flag-1', 'enabled' => true, 'description' => nil})
+      features.last.should  eq({'flag' => 'flag-2', 'enabled' => true, 'description' => nil})
+    end
+  end
+end


### PR DESCRIPTION
Excited about this new Bandiera project, this morning I have spent about a hour implementing a basic feature flag storage and retrieval functionality. Is not yet integrated with the rest, and will probably need some tweaks; but I think this implementation comes with some improvements over the OHM/ActiveModel approach:
- Uses Redis sets (instead of [keys](http://redis.io/commands/keys)) as a simple and efficient mechanisms to keep track of the features associated to a group. 
- Does not bother using ORM-like models and input validations, as the only two fields associated to a flag are its identifier key and its optional description string. Instead, it uses the 1i8n transliterate function to "sanitise" the flag id into a URL/redis-key fragment. 
- Hides Redis so that we can easily switch to something else if we feel like.
### Other ideas
- The service class below could extended so that its getter methods return read-only, presenter objects suitable to be directly serialised into JSON (or other formats if needed).
- It would be good to start a debate on what constitutes a good API design; and perhaps this project can be an opportunity to do so. We had some interesting discussions on this with Content Hub. I have found Jonathan Tweed's contributions particularly useful so far (specifically  [this](http://powerplant.nature.com/wiki/display/hubug/Hub+API+Design)).
