### PR TITLE
disconnect only if a connection exists.

### DIFF
--- a/lib/bandiera/db.rb
+++ b/lib/bandiera/db.rb
@@ -15,7 +15,9 @@ module Bandiera
     end
 
     def self.disconnect!
-      connection.disconnect
+      if @connection
+        @connection.disconnect
+      end
       @connection = nil
     end
 


### PR DESCRIPTION
previously it used to create the connection before disconnecting it.
