### PR TITLE
Initial adding of date/time contraints for a feature.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ coverage*
 artifacts*
 .env
 newrelic_agent.log
+.idea

--- a/db/migrations/010_add_date_range_to_features.rb
+++ b/db/migrations/010_add_date_range_to_features.rb
@@ -1,0 +1,8 @@
+Sequel.migration do
+  change do
+    alter_table(:features) do
+      add_column :start_time, Time, { default: nil }
+      add_column :end_time, Time, { default: nil }
+    end
+  end
+end

--- a/lib/bandiera/feature_service.rb
+++ b/lib/bandiera/feature_service.rb
@@ -70,7 +70,9 @@ module Bandiera
         description: params[:description],
         active:      params[:active],
         user_groups: params[:user_groups],
-        percentage:  params[:percentage]
+        percentage:  params[:percentage],
+        start_time:  params[:start_time],
+        end_time:    params[:end_time]
       }.delete_if { |_k, v| v.nil? }
       feature.update(fields)
     end

--- a/lib/bandiera/gui.rb
+++ b/lib/bandiera/gui.rb
@@ -155,6 +155,9 @@ module Bandiera
         errors << 'enter a feature name' unless param_present?(feature[:name])
         errors << 'enter a feature name without spaces' if param_has_whitespace?(feature[:name])
         errors << 'select a group' unless param_present?(feature[:group])
+        errors << 'enter an end time if you enter a start time' if param_present?(feature[:start_time]) && !param_present?(feature[:end_time])
+        errors << 'enter a start time if you enter an end time' if param_present?(feature[:end_time]) && !param_present?(feature[:start_time])
+        errors << 'enter an end time that is after your start time' if param_present?(feature[:end_time]) &&  param_present?(feature[:start_time]) && !times_in_order?(feature[:start_time], feature[:end_time])
         flash[:danger] = "You must #{errors.join(' and ')}."
         redirect on_error_url
       end

--- a/lib/bandiera/gui/views/_feature_form.erb
+++ b/lib/bandiera/gui/views/_feature_form.erb
@@ -72,7 +72,7 @@
 
   <div class="well">
     <h4>User Groups</h4>
-    <p>Use these options to have feature enabled for only a select number of users.</p>
+    <p>Use these options to have the feature enabled for only a select number of users.</p>
     <p>Note that these options will only be considered if the feature is active. Inactive features will not be enabled for any user, regardless of the settings in this section.</p>
     <div class="row">
       <div class="col-md-6">
@@ -88,6 +88,38 @@
           <label for="feature[user_groups][regex]">Regular Expression</label>
           <input type="text" class="form-control" id="feature_user_groups_regex" name="feature[user_groups][regex]" value="<%= @feature.user_groups_regex %>" />
           <p class="help-block">Enter a Ruby based regular expression - i.e. <code>.*_admin</code> will match anything that ends in <code>_admin</code>.  Please see <a href="http://rubular.com/">http://rubular.com/</a> for more information on Ruby regular expressions.</p>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="well">
+    <h4>Date Rage</h4>
+    <p>Use this option to have the feature enabled during a certain time range.</p>
+    <p>Please note that the feature must also be active before it's enabled for any users. Inactive features will be disabled for everyone, regardless of the settings in this section.</p>
+    <div class="row">
+      <div class="col-md-6">
+        <div class="form-group">
+          <label for="feature[start_time]">Start Time</label>
+          <div class="input-group date" id="datetimepicker-start">
+            <input type='text' class="form-control" id="feature_start_time" name="feature[start_time]" value="<%= @feature.start_time %>" />
+            <span class="input-group-addon">
+              <span class="glyphicon glyphicon-calendar"></span>
+            </span>
+          </div>
+          <p class="help-block">Enter a date/time combination in the format <code>YYYY-MM-DD HH:MM:SS</code>. For example 12:32pm on July 8th 2017 would be something like <code>2017-07-08 12:32:00</code>. <strong>Note: the machine's configured time zone is used</strong>.</p>
+        </div>
+      </div>
+      <div class="col-md-6">
+        <div class="form-group">
+          <label for="feature[end_time]">End Time</label>
+          <div class='input-group date' id='datetimepicker-end'>
+            <input type='text' class="form-control" id="feature_end_time" name="feature[end_time]" value="<%= @feature.end_time %>" />
+            <span class="input-group-addon">
+              <span class="glyphicon glyphicon-calendar"></span>
+            </span>
+          </div>
+          <p class="help-block">Enter a date/time combination in the format <code>YYYY-MM-DD HH:MM:SS</code>. For example 12:32pm on July 8th 2017 would be something like <code>2017-07-08 12:32:00</code>. <strong>Note: the machine's configured time zone is used</strong>.</p>
         </div>
       </div>
     </div>

--- a/lib/bandiera/gui/views/index.erb
+++ b/lib/bandiera/gui/views/index.erb
@@ -31,8 +31,9 @@
                     <th style="text-align:center">Active?</th>
                     <th style="text-align:center">User Groups?</th>
                     <th style="text-align:center">User %</th>
+                    <th style="text-align:center">Date Range</th>
                     <th width="20%">Name</th>
-                    <th width="40%">Description</th>
+                    <th width="30%">Description</th>
                     <th></th>
                   </tr>
                 </thead>
@@ -48,6 +49,11 @@
                       <td style="text-align:center">
                         <% if feature.percentage %>
                           <span class="fa fa-check"></span>
+                        <% end %>
+                      </td>
+                      <td style="text-align:center">
+                        <% if feature.start_time && feature.end_time %>
+                            <span class="fa fa-check"></span>
                         <% end %>
                       </td>
                       <td><%= feature.name %></td>

--- a/lib/bandiera/web_app_base.rb
+++ b/lib/bandiera/web_app_base.rb
@@ -50,7 +50,9 @@ module Bandiera
         description: params['description'],
         active:      params['active'] == 'true',
         user_groups: user_groups,
-        percentage:  params['percentage']
+        percentage:  params['percentage'],
+        start_time:  params['start_time'],
+        end_time:    params['end_time']
       }
     end
 
@@ -66,7 +68,14 @@ module Bandiera
     end
 
     def valid_feature_params?(feature)
-      param_present?(feature[:name]) && !param_has_whitespace?(feature[:name]) && param_present?(feature[:group])
+      valid_name = param_present?(feature[:name]) && !param_has_whitespace?(feature[:name])
+
+      valid_times = true
+      valid_times = false if param_present?(feature[:start_time]) && !param_present?(feature[:end_time])
+      valid_times = false if param_present?(feature[:end_time]) && !param_present?(feature[:start_time])
+      valid_times = false if param_present?(feature[:start_time]) && param_present?(feature[:end_time]) && !times_in_order?(feature[:start_time], feature[:end_time])
+
+      valid_name && param_present?(feature[:group]) && valid_times
     end
 
     def param_present?(param)
@@ -75,6 +84,13 @@ module Bandiera
 
     def param_has_whitespace?(param)
       param.match(/\s/)
+    end
+
+    def times_in_order?(start_time, end_time)
+      start_time = Time.parse(start_time)
+      end_time = Time.parse(end_time)
+
+      (start_time < end_time)
     end
   end
 end

--- a/spec/lib/bandiera/api_v2_spec.rb
+++ b/spec/lib/bandiera/api_v2_spec.rb
@@ -19,7 +19,9 @@ RSpec.describe Bandiera::APIv2 do
                                    { group: 'pubserv', name: 'show_metrics', description: '', active: false },
                                    { group: 'pubserv', name: 'use_content_hub', description: '', active: true },
                                    { group: 'shunter', name: 'stats_logging', description: '', active: true },
-                                   { group: 'shunter', name: 'use_img_serv', description: '', active: true, percentage: 50 }
+                                   { group: 'shunter', name: 'use_img_serv', description: '', active: true, percentage: 50 },
+                                   { group: 'parliament', name: 'in_dissolution', description: '', active: true, start_time: Time.now - 100, end_time: Time.now + 100 },
+                                   { group: 'parliament', name: 'show_search', description: '', active: true, start_time: Time.now + 100, end_time: Time.now + 200 }
                                  ])
   end
 
@@ -39,6 +41,10 @@ RSpec.describe Bandiera::APIv2 do
         'shunter' => {
           'stats_logging' => true,
           'use_img_serv'  => false
+        },
+        'parliament' => {
+          'in_dissolution' => true,
+          'show_search' => false,
         }
       }
 


### PR DESCRIPTION
Designed to be a first pass that uses the time zone configured on the server (or Docker image) running Bandiera when setting/calculating times.