### PR TITLE
Allow CORS (cross-site javascript) requests to the v2 API

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,6 @@ gem 'puma', require: false
 
 gem 'airbrake', require: false
 gem 'statsd-ruby', require: false
-gem 'newrelic_rpm'
 
 group :development do
   gem 'shotgun'

--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,7 @@ gem 'puma', require: false
 
 gem 'airbrake', require: false
 gem 'statsd-ruby', require: false
+gem 'rack-cors'
 
 group :development do
   gem 'shotgun'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -81,7 +81,6 @@ GEM
     mustermann (1.0.1)
     mysql2 (0.4.9)
     nenv (0.3.0)
-    newrelic_rpm (4.4.0.336)
     nokogiri (1.8.1)
       mini_portile2 (~> 2.3.0)
     nokogiri (1.8.1-java)
@@ -200,7 +199,6 @@ DEPENDENCIES
   lru_redux
   macmillan-utils
   mysql2
-  newrelic_rpm
   pg
   poltergeist
   pry

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -107,6 +107,7 @@ GEM
     puma (3.10.0)
     puma (3.10.0-java)
     rack (2.0.3)
+    rack-cors (1.0.1)
     rack-flash3 (1.0.5)
       rack
     rack-protection (2.0.0)
@@ -203,6 +204,7 @@ DEPENDENCIES
   poltergeist
   pry
   puma
+  rack-cors
   rack-flash3
   rack-test
   rake

--- a/config.ru
+++ b/config.ru
@@ -19,9 +19,20 @@ if ENV['AIRBRAKE_API_KEY'] && ENV['AIRBRAKE_PROJECT_ID']
   end
 end
 
-require 'macmillan/utils/statsd_middleware'
+if ENV['RACK_CORS_ORIGINS']
+  require 'rack/cors'
 
+  use Rack::Cors do
+    allow do
+      origins ENV['RACK_CORS_ORIGINS']
+      resource '/api/v2/*', headers: :any, methods: [:get, :options]
+    end
+  end
+end
+
+require 'macmillan/utils/statsd_middleware'
 use Macmillan::Utils::StatsdMiddleware, client: Bandiera.statsd
+
 use Rack::CommonLogger, Bandiera.logger
 use Airbrake::Rack::Middleware if ENV['AIRBRAKE_API_KEY'] && ENV['AIRBRAKE_PROJECT_ID']
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ services:
       RACK_ENV: 'development'
       DATABASE_URL: 'postgres://bandiera:bandiera@db/bandiera'
       LOG_TO_STDOUT: 'true'
+      RACK_CORS_ORIGINS: '*'
     links:
       - db
 

--- a/lib/bandiera.rb
+++ b/lib/bandiera.rb
@@ -3,7 +3,6 @@ require 'dotenv'
 require 'sequel'
 require 'macmillan/utils/logger'
 require_relative 'hash'
-require 'newrelic_rpm'
 
 GC::Profiler.enable
 


### PR DESCRIPTION
This change enables users to allow CORS requests to the v2 API on a Bandiera
instance - they just need to set the allowed calling domains via an
environment variable.