### PR TITLE
Cache size & ttl are now configurable

### DIFF
--- a/lib/bandiera/caching_feature_service.rb
+++ b/lib/bandiera/caching_feature_service.rb
@@ -9,10 +9,10 @@ module Bandiera
 
     attr_reader :cache
 
-    def initialize(delegate)
-      @cache = LruRedux::TTL::ThreadSafeCache.new(CACHE_SIZE, CACHE_TTL)
+    def initialize(delegate, cache_size: 100, cache_ttl: 10)
+      @cache = LruRedux::TTL::ThreadSafeCache.new(cache_size || 100, cache_ttl || 10)
 
-      super
+      super(delegate)
     end
 
     def find_group(name)

--- a/lib/bandiera/caching_feature_service.rb
+++ b/lib/bandiera/caching_feature_service.rb
@@ -4,13 +4,11 @@ require 'lru_redux'
 
 module Bandiera
   class CachingFeatureService < SimpleDelegator
-    CACHE_SIZE = 100
-    CACHE_TTL  = 10
 
     attr_reader :cache
 
-    def initialize(delegate, cache_size: 100, cache_ttl: 10)
-      @cache = LruRedux::TTL::ThreadSafeCache.new(cache_size || 100, cache_ttl || 10)
+    def initialize(delegate, cache_size: DEFAULT_CACHE_SIZE, cache_ttl: DEFAULT_CACHE_TTL)
+      @cache = LruRedux::TTL::ThreadSafeCache.new(cache_size || DEFAULT_CACHE_SIZE, cache_ttl || DEFAULT_CACHE_TTL)
 
       super(delegate)
     end
@@ -67,5 +65,10 @@ module Bandiera
 
       super
     end
+
+    private 
+
+    DEFAULT_CACHE_SIZE = 100
+    DEFAULT_CACHE_TTL  = 10
   end
 end

--- a/lib/bandiera/caching_feature_service.rb
+++ b/lib/bandiera/caching_feature_service.rb
@@ -5,6 +5,9 @@ require 'lru_redux'
 module Bandiera
   class CachingFeatureService < SimpleDelegator
 
+    DEFAULT_CACHE_SIZE = 100
+    DEFAULT_CACHE_TTL  = 10
+
     attr_reader :cache
 
     def initialize(delegate, cache_size: DEFAULT_CACHE_SIZE, cache_ttl: DEFAULT_CACHE_TTL)
@@ -65,10 +68,5 @@ module Bandiera
 
       super
     end
-
-    private
-
-    DEFAULT_CACHE_SIZE = 100
-    DEFAULT_CACHE_TTL  = 10
   end
 end

--- a/lib/bandiera/caching_feature_service.rb
+++ b/lib/bandiera/caching_feature_service.rb
@@ -66,7 +66,7 @@ module Bandiera
       super
     end
 
-    private 
+    private
 
     DEFAULT_CACHE_SIZE = 100
     DEFAULT_CACHE_TTL  = 10

--- a/lib/bandiera/caching_feature_service.rb
+++ b/lib/bandiera/caching_feature_service.rb
@@ -4,7 +4,6 @@ require 'lru_redux'
 
 module Bandiera
   class CachingFeatureService < SimpleDelegator
-
     DEFAULT_CACHE_SIZE = 100
     DEFAULT_CACHE_TTL  = 10
 

--- a/lib/bandiera/web_app_base.rb
+++ b/lib/bandiera/web_app_base.rb
@@ -12,8 +12,8 @@ module Bandiera
       enable :raise_errors if ENV['AIRBRAKE_API_KEY'] && ENV['AIRBRAKE_PROJECT_ID']
 
       set :feature_service, CachingFeatureService.new(FeatureService.new,
-                                                      cache_size: ENV['CACHE_SIZE']&.to_i,
-                                                      cache_ttl: ENV['CACHE_TTL']&.to_i)
+        cache_size: ENV['CACHE_SIZE']&.to_i,
+        cache_ttl: ENV['CACHE_TTL']&.to_i)
     end
 
     helpers do

--- a/lib/bandiera/web_app_base.rb
+++ b/lib/bandiera/web_app_base.rb
@@ -11,7 +11,9 @@ module Bandiera
       enable :logging
       enable :raise_errors if ENV['AIRBRAKE_API_KEY'] && ENV['AIRBRAKE_PROJECT_ID']
 
-      set :feature_service, CachingFeatureService.new(FeatureService.new, cache_size: ENV['CACHE_SIZE']&.to_i, cache_ttl: ENV['CACHE_TTL']&.to_i)
+      set :feature_service, CachingFeatureService.new(FeatureService.new,
+                                                      cache_size: ENV['CACHE_SIZE']&.to_i,
+                                                      cache_ttl: ENV['CACHE_TTL']&.to_i)
     end
 
     helpers do

--- a/lib/bandiera/web_app_base.rb
+++ b/lib/bandiera/web_app_base.rb
@@ -11,7 +11,7 @@ module Bandiera
       enable :logging
       enable :raise_errors if ENV['AIRBRAKE_API_KEY'] && ENV['AIRBRAKE_PROJECT_ID']
 
-      set :feature_service, CachingFeatureService.new(FeatureService.new)
+      set :feature_service, CachingFeatureService.new(FeatureService.new, cache_size: ENV['CACHE_SIZE']&.to_i, cache_ttl: ENV['CACHE_TTL']&.to_i)
     end
 
     helpers do

--- a/spec/lib/bandiera/caching_feature_service_spec.rb
+++ b/spec/lib/bandiera/caching_feature_service_spec.rb
@@ -601,7 +601,8 @@ RSpec.describe Bandiera::CachingFeatureService do
     describe 'with an unspecified cache size' do
       it 'evicts the lru item from the cache after the default cache size is exceeded' do
         expect(delegate).to receive(:fetch_feature).with('group1', 'feature1').twice.and_return(another_feature)
-        (2..101).each {|i| expect(delegate).to receive(:fetch_feature).with('group1', "feature#{i}").once.and_return(another_feature)}
+        (2..101).each {|i| expect(delegate).to receive(:fetch_feature).with('group1', "feature#{i}")
+            .once.and_return(another_feature)}
 
         Timecop.freeze(Time.local(2017, 1, 1, 12, 0, 0))
 
@@ -618,7 +619,8 @@ RSpec.describe Bandiera::CachingFeatureService do
 
       it 'evicts the lru item from the cache after the specified cache size is exceeded' do
         expect(delegate).to receive(:fetch_feature).with('group1', 'feature1').twice.and_return(another_feature)
-        (2..11).each {|i| expect(delegate).to receive(:fetch_feature).with('group1', "feature#{i}").once.and_return(another_feature)}
+        (2..11).each {|i| expect(delegate).to receive(:fetch_feature).with('group1', "feature#{i}")
+            .once.and_return(another_feature)}
 
         Timecop.freeze(Time.local(2017, 1, 1, 12, 0, 0))
 
@@ -635,7 +637,8 @@ RSpec.describe Bandiera::CachingFeatureService do
 
       it 'evicts the lru item from the cache after the default cache size is exceeded' do
         expect(delegate).to receive(:fetch_feature).with('group1', 'feature1').twice.and_return(another_feature)
-        (2..101).each {|i| expect(delegate).to receive(:fetch_feature).with('group1', "feature#{i}").once.and_return(another_feature)}
+        (2..101).each {|i| expect(delegate).to receive(:fetch_feature).with('group1', "feature#{i}")
+            .once.and_return(another_feature)}
 
         Timecop.freeze(Time.local(2017, 1, 1, 12, 0, 0))
 

--- a/spec/lib/bandiera/caching_feature_service_spec.rb
+++ b/spec/lib/bandiera/caching_feature_service_spec.rb
@@ -100,6 +100,48 @@ RSpec.describe Bandiera::CachingFeatureService do
 
       Timecop.return
     end
+
+    describe 'with a custom cache time' do
+      describe 'of a number' do
+        subject { Bandiera::CachingFeatureService.new(delegate, cache_ttl: 5) }
+
+        it 'expires the cache after the cache time' do
+          expect(delegate).to receive(:fetch_groups).twice.and_return(groups)
+
+          Timecop.freeze(Time.local(2017, 1, 1, 12, 0, 0))
+
+          3.times { subject.fetch_groups }
+
+          Timecop.travel(Time.local(2017, 1, 1, 12, 0, 6))
+
+          3.times { subject.fetch_groups }
+
+          Timecop.return
+        end
+      end
+
+      describe 'of nil' do
+        subject { Bandiera::CachingFeatureService.new(delegate, cache_ttl: nil) }
+
+        it 'expires the cache after the default cache time' do
+          expect(delegate).to receive(:fetch_groups).twice.and_return(groups)
+
+          Timecop.freeze(Time.local(2017, 1, 1, 12, 0, 0))
+
+          3.times { subject.fetch_groups }
+
+          Timecop.travel(Time.local(2017, 1, 1, 12, 0, 6))
+
+          3.times { subject.fetch_groups }
+
+          Timecop.travel(Time.local(2017, 1, 1, 12, 0, 11))
+
+          3.times { subject.fetch_groups }
+
+          Timecop.return
+        end
+      end
+    end
   end
 
   describe '#find_group' do
@@ -158,6 +200,48 @@ RSpec.describe Bandiera::CachingFeatureService do
       3.times { subject.find_group('group1') }
 
       Timecop.return
+    end
+
+    describe 'with a custom cache time' do
+      describe 'of a number' do
+        subject { Bandiera::CachingFeatureService.new(delegate, cache_ttl: 5) }
+
+        it 'expires the cache after the cache time' do
+          expect(delegate).to receive(:find_group).with('group1').twice.and_return(group)
+
+          Timecop.freeze(Time.local(2017, 1, 1, 12, 0, 0))
+
+          3.times { subject.find_group('group1') }
+
+          Timecop.travel(Time.local(2017, 1, 1, 12, 0, 6))
+
+          3.times { subject.find_group('group1') }
+
+          Timecop.return
+        end
+      end
+
+      describe 'of nil' do
+        subject { Bandiera::CachingFeatureService.new(delegate, cache_ttl: nil) }
+
+        it 'expires the cache after the default cache time' do
+          expect(delegate).to receive(:find_group).with('group1').twice.and_return(group)
+
+          Timecop.freeze(Time.local(2017, 1, 1, 12, 0, 0))
+
+          3.times { subject.find_group('group1') }
+
+          Timecop.travel(Time.local(2017, 1, 1, 12, 0, 6))
+
+          3.times { subject.find_group('group1') }
+
+          Timecop.travel(Time.local(2017, 1, 1, 12, 0, 11))
+
+          3.times { subject.find_group('group1') }
+
+          Timecop.return
+        end
+      end
     end
   end
 
@@ -366,6 +450,48 @@ RSpec.describe Bandiera::CachingFeatureService do
 
       Timecop.return
     end
+
+    describe 'with a custom cache time' do
+      describe 'of a number' do
+        subject { Bandiera::CachingFeatureService.new(delegate, cache_ttl: 5) }
+
+        it 'expires the cache after the cache time' do
+          expect(delegate).to receive(:fetch_feature).with('group1', 'feature1').twice.and_return(feature)
+
+          Timecop.freeze(Time.local(2017, 1, 1, 12, 0, 0))
+
+          3.times { subject.fetch_feature('group1', 'feature1') }
+
+          Timecop.travel(Time.local(2017, 1, 1, 12, 0, 6))
+
+          3.times { subject.fetch_feature('group1', 'feature1') }
+
+          Timecop.return
+        end
+      end
+
+      describe 'of nil' do
+        subject { Bandiera::CachingFeatureService.new(delegate, cache_ttl: nil) }
+
+        it 'expires the cache after the default cache time' do
+          expect(delegate).to receive(:fetch_feature).with('group1', 'feature1').twice.and_return(feature)
+
+          Timecop.freeze(Time.local(2017, 1, 1, 12, 0, 0))
+
+          3.times { subject.fetch_feature('group1', 'feature1') }
+
+          Timecop.travel(Time.local(2017, 1, 1, 12, 0, 6))
+
+          3.times { subject.fetch_feature('group1', 'feature1') }
+
+          Timecop.travel(Time.local(2017, 1, 1, 12, 0, 11))
+
+          3.times { subject.fetch_feature('group1', 'feature1') }
+
+          Timecop.return
+        end
+      end
+    end
   end
 
   describe '#fetch_group_features' do
@@ -424,6 +550,101 @@ RSpec.describe Bandiera::CachingFeatureService do
       3.times { subject.fetch_group_features('group1') }
 
       Timecop.return
+    end
+
+    describe 'with a custom cache time' do
+      describe 'of a number' do
+        subject { Bandiera::CachingFeatureService.new(delegate, cache_ttl: 5) }
+
+        it 'expires the cache after the cache time' do
+          expect(delegate).to receive(:fetch_group_features).with('group1').twice.and_return(features)
+
+          Timecop.freeze(Time.local(2017, 1, 1, 12, 0, 0))
+
+          3.times { subject.fetch_group_features('group1') }
+
+          Timecop.travel(Time.local(2017, 1, 1, 12, 0, 6))
+
+          3.times { subject.fetch_group_features('group1') }
+
+          Timecop.return
+        end
+      end
+
+      describe 'of nil' do
+        subject { Bandiera::CachingFeatureService.new(delegate, cache_ttl: nil) }
+
+        it 'expires the cache after the default cache time' do
+          expect(delegate).to receive(:fetch_group_features).with('group1').twice.and_return(features)
+
+          Timecop.freeze(Time.local(2017, 1, 1, 12, 0, 0))
+
+          3.times { subject.fetch_group_features('group1') }
+
+          Timecop.travel(Time.local(2017, 1, 1, 12, 0, 6))
+
+          3.times { subject.fetch_group_features('group1') }
+
+          Timecop.travel(Time.local(2017, 1, 1, 12, 0, 11))
+
+          3.times { subject.fetch_group_features('group1') }
+
+          Timecop.return
+        end
+      end
+    end
+  end
+
+  describe 'cache' do
+    let(:another_feature) { Bandiera::Feature.new(name: 'a_feature') }
+
+    describe 'with an unspecified cache size' do
+      it 'evicts the lru item from the cache after the default cache size is exceeded' do
+        expect(delegate).to receive(:fetch_feature).with('group1', 'feature1').twice.and_return(another_feature)
+        (2..101).each {|i| expect(delegate).to receive(:fetch_feature).with('group1', "feature#{i}").once.and_return(another_feature)}
+
+        Timecop.freeze(Time.local(2017, 1, 1, 12, 0, 0))
+
+        (1..101).each {|i| subject.fetch_feature('group1', "feature#{i}")}
+
+        subject.fetch_feature('group1', 'feature1')
+
+        Timecop.return
+      end
+    end
+
+    describe 'with a custom cache size' do
+      subject { Bandiera::CachingFeatureService.new(delegate, cache_size: 10) }
+
+      it 'evicts the lru item from the cache after the specified cache size is exceeded' do
+        expect(delegate).to receive(:fetch_feature).with('group1', 'feature1').twice.and_return(another_feature)
+        (2..11).each {|i| expect(delegate).to receive(:fetch_feature).with('group1', "feature#{i}").once.and_return(another_feature)}
+
+        Timecop.freeze(Time.local(2017, 1, 1, 12, 0, 0))
+
+        (1..11).each {|i| subject.fetch_feature('group1', "feature#{i}")}
+
+        subject.fetch_feature('group1', 'feature1')
+
+        Timecop.return
+      end
+    end
+
+    describe 'with a nil cache size' do
+      subject { Bandiera::CachingFeatureService.new(delegate, cache_size: nil) }
+
+      it 'evicts the lru item from the cache after the default cache size is exceeded' do
+        expect(delegate).to receive(:fetch_feature).with('group1', 'feature1').twice.and_return(another_feature)
+        (2..101).each {|i| expect(delegate).to receive(:fetch_feature).with('group1', "feature#{i}").once.and_return(another_feature)}
+
+        Timecop.freeze(Time.local(2017, 1, 1, 12, 0, 0))
+
+        (1..101).each {|i| subject.fetch_feature('group1', "feature#{i}")}
+
+        subject.fetch_feature('group1', 'feature1')
+
+        Timecop.return
+      end
     end
   end
 end

--- a/spec/lib/bandiera/caching_feature_service_spec.rb
+++ b/spec/lib/bandiera/caching_feature_service_spec.rb
@@ -601,8 +601,9 @@ RSpec.describe Bandiera::CachingFeatureService do
     describe 'with an unspecified cache size' do
       it 'evicts the lru item from the cache after the default cache size is exceeded' do
         expect(delegate).to receive(:fetch_feature).with('group1', 'feature1').twice.and_return(another_feature)
-        (2..101).each {|i| expect(delegate).to receive(:fetch_feature).with('group1', "feature#{i}")
-            .once.and_return(another_feature)}
+        (2..101).each do |i|
+          expect(delegate).to receive(:fetch_feature).with('group1', "feature#{i}").once.and_return(another_feature)
+        end
 
         Timecop.freeze(Time.local(2017, 1, 1, 12, 0, 0))
 
@@ -619,8 +620,9 @@ RSpec.describe Bandiera::CachingFeatureService do
 
       it 'evicts the lru item from the cache after the specified cache size is exceeded' do
         expect(delegate).to receive(:fetch_feature).with('group1', 'feature1').twice.and_return(another_feature)
-        (2..11).each {|i| expect(delegate).to receive(:fetch_feature).with('group1', "feature#{i}")
-            .once.and_return(another_feature)}
+        (2..11).each do |i|
+          expect(delegate).to receive(:fetch_feature).with('group1', "feature#{i}").once.and_return(another_feature)
+        end
 
         Timecop.freeze(Time.local(2017, 1, 1, 12, 0, 0))
 
@@ -637,8 +639,9 @@ RSpec.describe Bandiera::CachingFeatureService do
 
       it 'evicts the lru item from the cache after the default cache size is exceeded' do
         expect(delegate).to receive(:fetch_feature).with('group1', 'feature1').twice.and_return(another_feature)
-        (2..101).each {|i| expect(delegate).to receive(:fetch_feature).with('group1', "feature#{i}")
-            .once.and_return(another_feature)}
+        (2..101).each do |i|
+          expect(delegate).to receive(:fetch_feature).with('group1', "feature#{i}").once.and_return(another_feature)
+        end
 
         Timecop.freeze(Time.local(2017, 1, 1, 12, 0, 0))
 


### PR DESCRIPTION
This request adds:
* test coverage for the cache size
* configurability of the size & TTL via the `CACHE_SIZE` and `CACHE_TTL` environment variables

This was triggered by my *finally* reconciling the SN Cloudfoundry fork with this repo, and switching to the LRU cache (yes, I'm a terrible person). Unexpectedly we started getting a strong sawtooth pattern in response times, which was resolved by increasing the cache size to better suit our environment. Hence these changes, allowing us to do this on a per-env basis.