### PR TITLE
Introduced basic audit logging to console

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -2,6 +2,7 @@
 
 $LOAD_PATH.unshift(File.dirname(__FILE__) + '/lib')
 require 'bandiera'
+require 'bandiera/anonymous_audit_context'
 
 begin
   require 'rspec/core/rake_task'
@@ -37,11 +38,11 @@ namespace :db do
 
   task demo_reset: :environment do |_cmd, _args|
     db   = Bandiera::Db.connect
-    serv = Bandiera::FeatureService.new(db)
+    serv = Bandiera::FeatureService.new(db: db)
 
     db[:groups].delete
 
-    serv.add_features([
+    serv.add_features(Bandiera::AnonymousAuditContext.new, [
                         {
                           group:       'pubserv',
                           name:        'show-article-metrics',

--- a/lib/bandiera.rb
+++ b/lib/bandiera.rb
@@ -9,6 +9,9 @@ GC::Profiler.enable
 module Bandiera
   autoload :VERSION,                'bandiera/version'
   autoload :Db,                     'bandiera/db'
+  autoload :WebAuditContext,        'bandiera/web_audit_context'
+  autoload :BlackholeAuditLog,      'bandiera/blackhole_audit_log'
+  autoload :LoggingAuditLog,        'bandiera/logging_audit_log'
   autoload :Group,                  'bandiera/group'
   autoload :Feature,                'bandiera/feature'
   autoload :FeatureService,         'bandiera/feature_service'

--- a/lib/bandiera/anonymous_audit_context.rb
+++ b/lib/bandiera/anonymous_audit_context.rb
@@ -1,0 +1,9 @@
+module Bandiera
+  class AnonymousAuditContext
+
+    def user_id
+      '<anonymous>'
+    end
+
+  end
+end

--- a/lib/bandiera/anonymous_audit_context.rb
+++ b/lib/bandiera/anonymous_audit_context.rb
@@ -1,9 +1,7 @@
 module Bandiera
   class AnonymousAuditContext
-
     def user_id
       '<anonymous>'
     end
-
   end
 end

--- a/lib/bandiera/api_v1.rb
+++ b/lib/bandiera/api_v1.rb
@@ -22,7 +22,7 @@ module Bandiera
       group_name   = group_params.fetch('name', nil)
 
       if group_name
-        feature_service.add_group(group_name)
+        feature_service.add_group(audit_context, group_name)
         status 201
         render_json(group: { name: group_name })
       else
@@ -51,7 +51,7 @@ module Bandiera
       feature_params = process_v1_feature_params(params.fetch('feature', {}).merge('group' => group_name))
 
       with_valid_feature_params(feature_params) do
-        feature = feature_service.add_feature(feature_params)
+        feature = feature_service.add_feature(audit_context, feature_params)
         status 201
         render_json(feature: feature.as_v1_json)
       end
@@ -90,7 +90,7 @@ module Bandiera
       feature_params[:group] = group_name unless feature_params[:group]
 
       with_valid_feature_params(feature_params, true) do
-        feature = feature_service.update_feature(group_name, feature_name, feature_params)
+        feature = feature_service.update_feature(audit_context, group_name, feature_name, feature_params)
         status 200
         render_json(feature: feature.as_v1_json)
       end

--- a/lib/bandiera/blackhole_audit_log.rb
+++ b/lib/bandiera/blackhole_audit_log.rb
@@ -1,0 +1,7 @@
+module Bandiera
+  class BlackholeAuditLog
+
+    def record(_audit_context, _action, _object_name, _params) end
+
+  end
+end

--- a/lib/bandiera/blackhole_audit_log.rb
+++ b/lib/bandiera/blackhole_audit_log.rb
@@ -1,7 +1,5 @@
 module Bandiera
   class BlackholeAuditLog
-
     def record(_audit_context, _action, _object_name, _params) end
-
   end
 end

--- a/lib/bandiera/caching_feature_service.rb
+++ b/lib/bandiera/caching_feature_service.rb
@@ -31,21 +31,21 @@ module Bandiera
       cache.getset(:"fetch_feature:#{group}:#{feature_name}") { super }
     end
 
-    def add_group(group)
+    def add_group(audit_context, group)
       cache.delete(:"find_group:#{group}")
       cache.delete(:fetch_groups)
 
       super
     end
 
-    def add_feature(data)
+    def add_feature(audit_context, data)
       cache.delete(:"fetch_feature:#{data[:group]}:#{data[:name]}")
       cache.delete(:"fetch_group_features:#{data[:group]}")
 
       super
     end
 
-    def add_features(features)
+    def add_features(audit_context, features)
       features.each do |data|
         cache.delete(:"fetch_feature:#{data[:group]}:#{data[:name]}")
         cache.delete(:"fetch_group_features:#{data[:group]}")
@@ -54,14 +54,14 @@ module Bandiera
       super
     end
 
-    def remove_feature(group, feature_name)
+    def remove_feature(audit_context, group, feature_name)
       cache.delete(:"fetch_feature:#{group}:#{feature_name}")
       cache.delete(:"fetch_group_features:#{group}")
 
       super
     end
 
-    def update_feature(group, feature_name, feature_data)
+    def update_feature(audit_context, group, feature_name, feature_data)
       cache.delete(:"fetch_feature:#{group}:#{feature_name}")
       cache.delete(:"fetch_group_features:#{group}")
 

--- a/lib/bandiera/gui.rb
+++ b/lib/bandiera/gui.rb
@@ -55,7 +55,7 @@ module Bandiera
       group_name = params[:group][:name]
 
       with_valid_group_params(group_name, '/new/group') do
-        feature_service.add_group(group_name)
+        feature_service.add_group(audit_context, group_name)
         flash[:success] = 'Group created.'
         redirect '/'
       end
@@ -81,7 +81,7 @@ module Bandiera
       feature = process_v2_feature_params(params[:feature])
 
       with_valid_feature_params(feature, '/new/feature') do
-        feature_service.add_feature(feature)
+        feature_service.add_feature(audit_context, feature)
         flash[:success] = 'Feature created.'
         redirect '/'
       end
@@ -108,7 +108,7 @@ module Bandiera
       new_feature = process_v2_feature_params(params[:feature])
 
       with_valid_feature_params(new_feature, "/groups/#{prev_group}/features/#{prev_name}/edit") do
-        feature_service.update_feature(prev_group, prev_name, new_feature)
+        feature_service.update_feature(audit_context, prev_group, prev_name, new_feature)
         flash[:success] = 'Feature updated.'
         redirect '/'
       end
@@ -125,7 +125,7 @@ module Bandiera
       active      = feat_params[:active] == 'true'
 
       if group && name && !active.nil?
-        feature_service.update_feature(group, name, { active: active })
+        feature_service.update_feature(audit_context, group, name, { active: active })
         status 200
         content_type :json
         '{}'
@@ -140,7 +140,7 @@ module Bandiera
     end
 
     def _get_delete_feature(group_name, feature_name)
-      feature_service.remove_feature(group_name, feature_name)
+      feature_service.remove_feature(audit_context, group_name, feature_name)
       flash[:success] = 'Feature deleted.'
       redirect '/'
     end

--- a/lib/bandiera/logging_audit_log.rb
+++ b/lib/bandiera/logging_audit_log.rb
@@ -19,5 +19,6 @@ module Bandiera
         ''
       end
     end
+
   end
 end

--- a/lib/bandiera/logging_audit_log.rb
+++ b/lib/bandiera/logging_audit_log.rb
@@ -1,0 +1,25 @@
+module Bandiera
+  class LoggingAuditLog
+
+    def initialize(logger)
+      @logger = logger
+    end
+
+    def record(audit_context, action, object_name, params = {})
+      @logger.log("AUDIT [#{audit_context.user_id}] #{action} #{object_name}#{format(params)}")
+    rescue
+      # ignored
+    end
+
+    private
+
+    def format(params)
+      if params && !params.empty?
+        ' (' + params.map {|key, value| "#{key}: #{value}"}.join(', ') + ')'
+      else
+        ''
+      end
+    end
+
+  end
+end

--- a/lib/bandiera/logging_audit_log.rb
+++ b/lib/bandiera/logging_audit_log.rb
@@ -1,6 +1,5 @@
 module Bandiera
   class LoggingAuditLog
-
     def initialize(logger)
       @logger = logger
     end
@@ -20,6 +19,5 @@ module Bandiera
         ''
       end
     end
-
   end
 end

--- a/lib/bandiera/web_app_base.rb
+++ b/lib/bandiera/web_app_base.rb
@@ -11,7 +11,8 @@ module Bandiera
       enable :logging
       enable :raise_errors if ENV['AIRBRAKE_API_KEY'] && ENV['AIRBRAKE_PROJECT_ID']
 
-      set :feature_service, CachingFeatureService.new(FeatureService.new,
+      audit_log = LoggingAuditLog.new(Bandiera.logger)
+      set :feature_service, CachingFeatureService.new(FeatureService.new(audit_log),
         cache_size: ENV['CACHE_SIZE']&.to_i,
         cache_ttl: ENV['CACHE_TTL']&.to_i)
     end
@@ -95,6 +96,10 @@ module Bandiera
       end_time = Time.parse(end_time)
 
       (start_time < end_time)
+    end
+
+    def audit_context
+      Bandiera::WebAuditContext.new(request)
     end
   end
 end

--- a/lib/bandiera/web_audit_context.rb
+++ b/lib/bandiera/web_audit_context.rb
@@ -1,6 +1,5 @@
 module Bandiera
   class WebAuditContext
-
     def initialize(request)
       @request = request
     end
@@ -8,6 +7,5 @@ module Bandiera
     def user_id
       @request.ip
     end
-
   end
 end

--- a/lib/bandiera/web_audit_context.rb
+++ b/lib/bandiera/web_audit_context.rb
@@ -1,0 +1,13 @@
+module Bandiera
+  class WebAuditContext
+
+    def initialize(request)
+      @request = request
+    end
+
+    def user_id
+      @request.ip
+    end
+
+  end
+end

--- a/spec/lib/bandiera/anonymous_audit_context_spec.rb
+++ b/spec/lib/bandiera/anonymous_audit_context_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+
+RSpec.describe Bandiera::AnonymousAuditContext do
+  subject { Bandiera::AnonymousAuditContext.new }
+
+  it_behaves_like 'an audit context'
+
+  describe '#user_id' do
+    it 'returns an anonymous identifier' do
+      expect(subject.user_id).to eq('<anonymous>')
+    end
+  end
+end

--- a/spec/lib/bandiera/api_v1_spec.rb
+++ b/spec/lib/bandiera/api_v1_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe Bandiera::APIv1 do
   include Rack::Test::Methods
 
   let(:instance) { Bandiera::APIv1 }
+  let(:audit_context) { Bandiera::AnonymousAuditContext.new }
   let(:app) do
     app_instance = instance
     Rack::Builder.new do
@@ -24,7 +25,7 @@ RSpec.describe Bandiera::APIv1 do
 
   before do
     service = instance.settings.feature_service
-    service.add_features([
+    service.add_features(audit_context, [
                            { group: 'pubserv',   name: 'show_subjects',  description: 'Show all subject related features', active: false },
                            { group: 'pubserv',   name: 'show_search',    description: 'Show the search bar',               active: true  },
                            { group: 'pubserv',   name: 'xmas_mode',      description: 'Xmas mode: SNOWFLAKES!',            active: false },

--- a/spec/lib/bandiera/api_v2_spec.rb
+++ b/spec/lib/bandiera/api_v2_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe Bandiera::APIv2 do
   include Rack::Test::Methods
 
   let(:instance) { Bandiera::APIv2 }
+  let(:audit_context) { Bandiera::AnonymousAuditContext.new }
   let(:app) do
     app_instance = instance
     Rack::Builder.new do
@@ -25,7 +26,7 @@ RSpec.describe Bandiera::APIv2 do
 
   before do
     service = instance.settings.feature_service
-    service.add_features([
+    service.add_features(audit_context, [
                            { group: 'pubserv',    name: 'show_subjects',   description: '', active: true, user_groups: { list: ['editor'], regex: '' } },
                            { group: 'pubserv',    name: 'show_metrics',    description: '', active: false },
                            { group: 'pubserv',    name: 'use_content_hub', description: '', active: true },

--- a/spec/lib/bandiera/blackhole_audit_log_spec.rb
+++ b/spec/lib/bandiera/blackhole_audit_log_spec.rb
@@ -1,0 +1,7 @@
+require 'spec_helper'
+
+RSpec.describe Bandiera::BlackholeAuditLog do
+  subject { Bandiera::BlackholeAuditLog.new }
+
+  it_behaves_like 'an audit log'
+end

--- a/spec/lib/bandiera/caching_feature_service_spec.rb
+++ b/spec/lib/bandiera/caching_feature_service_spec.rb
@@ -362,7 +362,8 @@ RSpec.describe Bandiera::CachingFeatureService do
     let(:updated_feature) { { description: 'updated', active: true } }
 
     it 'updates the feature on the delegate' do
-      expect(delegate).to receive(:update_feature).with(audit_context, 'group1', 'feature1', updated_feature).and_return(feature)
+      expect(delegate).to receive(:update_feature).with(audit_context, 'group1', 'feature1', updated_feature)
+        .and_return(feature)
 
       result = subject.update_feature(audit_context, 'group1', 'feature1', updated_feature)
       expect(result).to eq(feature)

--- a/spec/lib/bandiera/caching_feature_service_spec.rb
+++ b/spec/lib/bandiera/caching_feature_service_spec.rb
@@ -3,11 +3,12 @@
 require 'spec_helper'
 
 RSpec.describe Bandiera::CachingFeatureService do
-  let(:delegate) { Bandiera::FeatureService.new }
-  let(:group)    { Bandiera::Group.new(name: 'group1') }
-  let(:groups)   { [Bandiera::Group.new(name: 'group1')] }
-  let(:feature)  { Bandiera::Feature.new(name: 'feature1') }
-  let(:features) { [Bandiera::Feature.new(name: 'feature1'), Bandiera::Feature.new(name: 'feature2')] }
+  let(:delegate)      { Bandiera::FeatureService.new }
+  let(:audit_context) { Bandiera::AnonymousAuditContext.new }
+  let(:group)         { Bandiera::Group.new(name: 'group1') }
+  let(:groups)        { [Bandiera::Group.new(name: 'group1')] }
+  let(:feature)       { Bandiera::Feature.new(name: 'feature1') }
+  let(:features)      { [Bandiera::Feature.new(name: 'feature1'), Bandiera::Feature.new(name: 'feature2')] }
 
   subject { Bandiera::CachingFeatureService.new(delegate) }
 
@@ -15,30 +16,30 @@ RSpec.describe Bandiera::CachingFeatureService do
 
   describe '#add_group' do
     it 'adds the group to the delegate' do
-      expect(delegate).to receive(:add_group).with('burgers').and_return(group)
+      expect(delegate).to receive(:add_group).with(audit_context, 'burgers').and_return(group)
 
-      result = subject.add_group('burgers')
+      result = subject.add_group(audit_context, 'burgers')
       expect(result).to eq(group)
     end
 
     it 'invalidates the groups cache' do
       expect(delegate).to receive(:fetch_groups).twice.and_return(groups)
-      allow(delegate).to receive(:add_group).with('burgers')
+      allow(delegate).to receive(:add_group).with(audit_context, 'burgers')
 
       subject.fetch_groups
-      subject.add_group('burgers')
+      subject.add_group(audit_context, 'burgers')
       subject.fetch_groups
     end
 
     it 'only invalidates the the groups by name cache for that particular group' do
       expect(delegate).to receive(:find_group).with('other_group').once.and_return(group)
       expect(delegate).to receive(:find_group).with('burgers').twice.and_return(group)
-      allow(delegate).to receive(:add_group).with('burgers')
+      allow(delegate).to receive(:add_group).with(audit_context, 'burgers')
 
       subject.find_group('other_group')
       subject.find_group('burgers')
 
-      subject.add_group('burgers')
+      subject.add_group(audit_context, 'burgers')
 
       subject.find_group('other_group')
       subject.find_group('burgers')
@@ -249,21 +250,21 @@ RSpec.describe Bandiera::CachingFeatureService do
     let(:feature_data) { { name: 'feature1', group: 'group1', description: '', active: true } }
 
     it 'adds the feature to the delegate' do
-      expect(delegate).to receive(:add_feature).with(feature_data).and_return(feature)
+      expect(delegate).to receive(:add_feature).with(audit_context, feature_data).and_return(feature)
 
-      result = subject.add_feature(feature_data)
+      result = subject.add_feature(audit_context, feature_data)
       expect(result).to eq(feature)
     end
 
     it 'invalidates the fetch feature cache for that particular feature' do
       expect(delegate).to receive(:fetch_feature).with('group1', 'feature1').twice.and_return(feature)
       expect(delegate).to receive(:fetch_feature).with('group1', 'feature2').once.and_return(feature)
-      allow(delegate).to receive(:add_feature).with(feature_data)
+      allow(delegate).to receive(:add_feature).with(audit_context, feature_data)
 
       3.times { subject.fetch_feature('group1', 'feature1') }
       3.times { subject.fetch_feature('group1', 'feature2') }
 
-      subject.add_feature(feature_data)
+      subject.add_feature(audit_context, feature_data)
 
       3.times { subject.fetch_feature('group1', 'feature1') }
       3.times { subject.fetch_feature('group1', 'feature2') }
@@ -271,11 +272,11 @@ RSpec.describe Bandiera::CachingFeatureService do
 
     it 'invalidates the fetch group features cache' do
       expect(delegate).to receive(:fetch_group_features).with('group1').twice.and_return(features)
-      allow(delegate).to receive(:add_feature).with(feature_data)
+      allow(delegate).to receive(:add_feature).with(audit_context, feature_data)
 
       3.times { subject.fetch_group_features('group1') }
 
-      subject.add_feature(feature_data)
+      subject.add_feature(audit_context, feature_data)
 
       3.times { subject.fetch_group_features('group1') }
     end
@@ -290,9 +291,9 @@ RSpec.describe Bandiera::CachingFeatureService do
     end
 
     it 'adds the features to the delegate' do
-      expect(delegate).to receive(:add_features).with(features_data).and_return(features)
+      expect(delegate).to receive(:add_features).with(audit_context, features_data).and_return(features)
 
-      result = subject.add_features(features_data)
+      result = subject.add_features(audit_context, features_data)
 
       expect(result).to eq(features)
     end
@@ -301,13 +302,13 @@ RSpec.describe Bandiera::CachingFeatureService do
       expect(delegate).to receive(:fetch_feature).with('group1', 'feature1').twice.and_return(feature)
       expect(delegate).to receive(:fetch_feature).with('group1', 'feature2').twice.and_return(feature)
       expect(delegate).to receive(:fetch_feature).with('group1', 'feature3').once.and_return(feature)
-      allow(delegate).to receive(:add_features).with(features_data)
+      allow(delegate).to receive(:add_features).with(audit_context, features_data)
 
       3.times { subject.fetch_feature('group1', 'feature1') }
       3.times { subject.fetch_feature('group1', 'feature2') }
       3.times { subject.fetch_feature('group1', 'feature3') }
 
-      subject.add_features(features_data)
+      subject.add_features(audit_context, features_data)
 
       3.times { subject.fetch_feature('group1', 'feature1') }
       3.times { subject.fetch_feature('group1', 'feature2') }
@@ -316,11 +317,11 @@ RSpec.describe Bandiera::CachingFeatureService do
 
     it 'invalidates the fetch group features cache' do
       expect(delegate).to receive(:fetch_group_features).with('group1').twice.and_return(features)
-      allow(delegate).to receive(:add_features).with(features_data)
+      allow(delegate).to receive(:add_features).with(audit_context, features_data)
 
       3.times { subject.fetch_group_features('group1') }
 
-      subject.add_features(features_data)
+      subject.add_features(audit_context, features_data)
 
       3.times { subject.fetch_group_features('group1') }
     end
@@ -328,30 +329,30 @@ RSpec.describe Bandiera::CachingFeatureService do
 
   describe '#remove_feature' do
     it 'removes the feature from the delegate' do
-      expect(delegate).to receive(:remove_feature).with('group1', 'feature2').and_return(1)
+      expect(delegate).to receive(:remove_feature).with(audit_context, 'group1', 'feature2').and_return(1)
 
-      result = subject.remove_feature('group1', 'feature2')
+      result = subject.remove_feature(audit_context, 'group1', 'feature2')
       expect(result).to eq(1)
     end
 
     it 'invalidates the fetch feature cache for that particlar feature' do
       expect(delegate).to receive(:fetch_feature).with('group1', 'feature1').and_return(feature, nil)
-      expect(delegate).to receive(:remove_feature).with('group1', 'feature1')
+      expect(delegate).to receive(:remove_feature).with(audit_context, 'group1', 'feature1')
 
       3.times { expect(subject.fetch_feature('group1', 'feature1')).to eq(feature) }
 
-      subject.remove_feature('group1', 'feature1')
+      subject.remove_feature(audit_context, 'group1', 'feature1')
 
       3.times { expect(subject.fetch_feature('group1', 'feature1')).to be_nil }
     end
 
     it 'invalidates the fetch group features cache' do
       expect(delegate).to receive(:fetch_group_features).with('group1').twice.and_return(features)
-      allow(delegate).to receive(:remove_feature).with('group1', 'feature2')
+      allow(delegate).to receive(:remove_feature).with(audit_context, 'group1', 'feature2')
 
       3.times { subject.fetch_group_features('group1') }
 
-      subject.remove_feature('group1', 'feature2')
+      subject.remove_feature(audit_context, 'group1', 'feature2')
 
       3.times { subject.fetch_group_features('group1') }
     end
@@ -361,21 +362,21 @@ RSpec.describe Bandiera::CachingFeatureService do
     let(:updated_feature) { { description: 'updated', active: true } }
 
     it 'updates the feature on the delegate' do
-      expect(delegate).to receive(:update_feature).with('group1', 'feature1', updated_feature).and_return(feature)
+      expect(delegate).to receive(:update_feature).with(audit_context, 'group1', 'feature1', updated_feature).and_return(feature)
 
-      result = subject.update_feature('group1', 'feature1', updated_feature)
+      result = subject.update_feature(audit_context, 'group1', 'feature1', updated_feature)
       expect(result).to eq(feature)
     end
 
     it 'invalidates the fetch feature cache for this particular feature' do
       expect(delegate).to receive(:fetch_feature).with('group1', 'feature1').twice.and_return(feature)
       expect(delegate).to receive(:fetch_feature).with('group1', 'feature2').once.and_return(feature)
-      allow(delegate).to receive(:update_feature).with('group1', 'feature1', updated_feature)
+      allow(delegate).to receive(:update_feature).with(audit_context, 'group1', 'feature1', updated_feature)
 
       3.times { subject.fetch_feature('group1', 'feature1') }
       3.times { subject.fetch_feature('group1', 'feature2') }
 
-      subject.update_feature('group1', 'feature1', updated_feature)
+      subject.update_feature(audit_context, 'group1', 'feature1', updated_feature)
 
       3.times { subject.fetch_feature('group1', 'feature1') }
       3.times { subject.fetch_feature('group1', 'feature2') }
@@ -383,11 +384,11 @@ RSpec.describe Bandiera::CachingFeatureService do
 
     it 'invalidates the fetch group features cache' do
       expect(delegate).to receive(:fetch_group_features).with('group1').twice.and_return(features)
-      allow(delegate).to receive(:update_feature).with('group1', 'feature1', updated_feature)
+      allow(delegate).to receive(:update_feature).with(audit_context, 'group1', 'feature1', updated_feature)
 
       3.times { subject.fetch_group_features('group1') }
 
-      subject.update_feature('group1', 'feature1', updated_feature)
+      subject.update_feature(audit_context, 'group1', 'feature1', updated_feature)
 
       3.times { subject.fetch_group_features('group1') }
     end

--- a/spec/lib/bandiera/feature_service_spec.rb
+++ b/spec/lib/bandiera/feature_service_spec.rb
@@ -1,7 +1,72 @@
 require 'spec_helper'
 
 RSpec.describe Bandiera::FeatureService do
-  subject { Bandiera::FeatureService.new }
+  let(:audit_context) { Bandiera::AnonymousAuditContext.new }
+  let(:audit_log) { instance_double('Bandiera::AuditLog') }
+  subject { Bandiera::FeatureService.new(audit_log) }
+
+  before do
+    allow(audit_log).to receive(:record)
+  end
 
   it_behaves_like 'a feature service'
+
+  describe '#add_group' do
+    it 'records to the audit log' do
+      expect(audit_log).to receive(:record).with(audit_context, :add, :group, name: 'cheese')
+
+      subject.add_group(audit_context, 'cheese')
+    end
+  end
+
+  describe '#add_feature' do
+    it 'records to the audit log' do
+      expect(audit_log).to receive(:record)
+        .with(audit_context, :add, :feature, name: 'feat', group: 'group', active: false)
+
+      subject.add_feature(audit_context, name: 'feat', group: 'group', active: false)
+    end
+  end
+
+  describe '#add_features' do
+    it 'records to the audit log' do
+      expect(audit_log).to receive(:record)
+        .with(audit_context, :add, :feature, name: 'feature1', group: 'group_name', active: nil)
+        .with(audit_context, :add, :feature, name: 'feature2', group: 'group_name', active: nil)
+        .with(audit_context, :add, :feature, name: 'wibble', group: 'something_else', active: nil)
+
+      subject.add_features(audit_context, [
+          { name: 'feature1', group: 'group_name' },
+          { name: 'feature2', group: 'group_name' },
+          { name: 'wibble', group: 'something_else' }
+      ])
+    end
+  end
+
+  describe '#remove_feature' do
+    before do
+      subject.add_feature(audit_context, { name: 'feat', group: 'group', description: '', active: false })
+    end
+
+    it 'records to the audit log' do
+      expect(audit_log).to receive(:record)
+        .with(audit_context, :remove, :feature, name: 'feat', group: 'group')
+
+      subject.remove_feature(audit_context, 'group', 'feat')
+    end
+  end
+
+  describe '#update_feature' do
+    before do
+      subject.add_feature(audit_context, { name: 'feat', group: 'group', description: '', active: false })
+    end
+
+    it 'records to the audit log' do
+      expect(audit_log).to receive(:record)
+        .with(audit_context, :update, :feature, name: 'feat', group: 'group',
+          fields: { description: 'updated', active: true })
+
+      subject.update_feature(audit_context, 'group', 'feat', description: 'updated', active: true)
+    end
+  end
 end

--- a/spec/lib/bandiera/gui_spec.rb
+++ b/spec/lib/bandiera/gui_spec.rb
@@ -8,6 +8,8 @@ require 'capybara/poltergeist'
 RSpec.describe Bandiera::GUI do
   include Capybara::DSL
 
+  let(:audit_context) { Bandiera::AnonymousAuditContext.new }
+
   before(:all) do
     app = Bandiera::GUI.new
     Capybara.app = Rack::Builder.new do
@@ -20,7 +22,7 @@ RSpec.describe Bandiera::GUI do
   end
 
   before do
-    @service.add_features([
+    @service.add_features(audit_context, [
                             { group: 'pubserv',    name: 'show_subjects',  description: 'Show all subject related features', active: false },
                             { group: 'pubserv',    name: 'show_search',    description: 'Show the search bar',               active: true  },
                             { group: 'laserwolf',  name: 'enable_caching', description: 'Enable caching',                    active: false },

--- a/spec/lib/bandiera/logging_audit_log_spec.rb
+++ b/spec/lib/bandiera/logging_audit_log_spec.rb
@@ -1,0 +1,35 @@
+require 'spec_helper'
+
+RSpec.describe Bandiera::LoggingAuditLog do
+  let(:logger) { instance_double('Logger') }
+  let(:audit_context) { Bandiera::AnonymousAuditContext.new }
+  subject { Bandiera::LoggingAuditLog.new(logger) }
+
+  it_behaves_like 'an audit log'
+
+  describe '#record' do
+    it 'records the audit message to the logger' do
+      expect(logger).to receive(:log).with('AUDIT [<anonymous>] add foodstuff (name: burger)')
+
+      subject.record(audit_context, :add, :foodstuff, name: 'burger')
+    end
+
+    it 'handles no parameters' do
+      expect(logger).to receive(:log).with('AUDIT [<anonymous>] eat cake')
+
+      subject.record(audit_context, :eat, :cake)
+    end
+
+    it 'handles multiple parameters' do
+      expect(logger).to receive(:log).with('AUDIT [<anonymous>] add foodstuff (name: burger, type: rare)')
+
+      subject.record(audit_context, :add, :foodstuff, name: 'burger', type: 'rare')
+    end
+
+    it 'does not propagate exceptions' do
+      expect(logger).to receive(:log).and_throw RuntimeError.new('This should not propagate')
+
+      subject.record(audit_context, :add, :foodstuff, name: 'burger')
+    end
+  end
+end

--- a/spec/lib/bandiera/web_audit_context_spec.rb
+++ b/spec/lib/bandiera/web_audit_context_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+
+RSpec.describe Bandiera::WebAuditContext do
+  let(:request) { Rack::Request.new(Rack::MockRequest.env_for('/a/path', 'REMOTE_ADDR' => '1.2.3.4')) }
+  subject { Bandiera::WebAuditContext.new(request) }
+
+  it_behaves_like 'an audit context'
+
+  describe '#user_id' do
+    it 'returns the current remote IP address' do
+      expect(subject.user_id).to eq('1.2.3.4')
+    end
+  end
+end

--- a/spec/shared_examples/a_feature_service.rb
+++ b/spec/shared_examples/a_feature_service.rb
@@ -28,7 +28,7 @@ shared_examples_for 'a feature service' do
 
       it 'does not create a new group' do
         expect { subject.add_feature(audit_context, feat_data) }
-          .to_not change { db[:groups].count }
+          .to_not(change { db[:groups].count })
       end
 
       it 'returns the created feature' do
@@ -222,7 +222,7 @@ shared_examples_for 'a feature service' do
 
       it 'does not remove the group' do
         expect { subject.remove_feature(audit_context, 'group', 'feat') }
-          .to_not change { db[:groups].count }
+          .to_not(change { db[:groups].count })
       end
     end
   end

--- a/spec/shared_examples/an_audit_context.rb
+++ b/spec/shared_examples/an_audit_context.rb
@@ -1,11 +1,9 @@
 # frozen_string_literal: true
 
 shared_examples_for 'an audit context' do
-
   describe 'auditing information' do
     it 'responds to #user_id?' do
       should respond_to(:user_id).with(0).arguments
     end
   end
-
 end

--- a/spec/shared_examples/an_audit_context.rb
+++ b/spec/shared_examples/an_audit_context.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+shared_examples_for 'an audit context' do
+
+  describe 'auditing information' do
+    it 'responds to #user_id?' do
+      should respond_to(:user_id).with(0).arguments
+    end
+  end
+
+end

--- a/spec/shared_examples/an_audit_log.rb
+++ b/spec/shared_examples/an_audit_log.rb
@@ -1,11 +1,9 @@
 # frozen_string_literal: true
 
 shared_examples_for 'an audit log' do
-
   describe 'logging methods' do
     it 'responds to #record?' do
       should respond_to(:record).with(4).arguments
     end
   end
-
 end

--- a/spec/shared_examples/an_audit_log.rb
+++ b/spec/shared_examples/an_audit_log.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+shared_examples_for 'an audit log' do
+
+  describe 'logging methods' do
+    it 'responds to #record?' do
+      should respond_to(:record).with(4).arguments
+    end
+  end
+
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,6 +11,7 @@ require 'timecop'
 require 'pry'
 
 require_relative '../lib/bandiera'
+require_relative '../lib/bandiera/anonymous_audit_context'
 load File.expand_path('../../Rakefile', __FILE__)
 
 # load shared_examples


### PR DESCRIPTION
This is a start at addressing #51.

It adds a basic audit logger that logs to the existing `logger`. It's intended to be a base to build upon - the next path I'm likely to head down is recording events in a DB table, followed by a GUI view of the auditing information.

Given we've no user auth at present we're just logging the request ID. Ideally this would be expanded in the future to allow pluggable auth so we can track the active user as well.