### PR TITLE
Audit log now logs to a database table

### DIFF
--- a/db/migrations/011_create_audit_records.rb
+++ b/db/migrations/011_create_audit_records.rb
@@ -1,0 +1,12 @@
+Sequel.migration do
+  change do
+    create_table(:audit_records) do
+      primary_key :id
+      Time :timestamp, null: false
+      String :user, null: false
+      String :action, null: false
+      String :object, null: false
+      String :params, text: true
+    end
+  end
+end

--- a/lib/bandiera.rb
+++ b/lib/bandiera.rb
@@ -12,6 +12,7 @@ module Bandiera
   autoload :WebAuditContext,        'bandiera/web_audit_context'
   autoload :BlackholeAuditLog,      'bandiera/blackhole_audit_log'
   autoload :LoggingAuditLog,        'bandiera/logging_audit_log'
+  autoload :AuditRecord,            'bandiera/audit_record'
   autoload :Group,                  'bandiera/group'
   autoload :Feature,                'bandiera/feature'
   autoload :FeatureService,         'bandiera/feature_service'

--- a/lib/bandiera/audit_record.rb
+++ b/lib/bandiera/audit_record.rb
@@ -1,0 +1,8 @@
+module Bandiera
+  class AuditRecord < Sequel::Model
+    def before_save
+      self.timestamp ||= Time.now
+      super
+    end
+  end
+end

--- a/lib/bandiera/web_app_base.rb
+++ b/lib/bandiera/web_app_base.rb
@@ -11,7 +11,7 @@ module Bandiera
       enable :logging
       enable :raise_errors if ENV['AIRBRAKE_API_KEY'] && ENV['AIRBRAKE_PROJECT_ID']
 
-      audit_log = LoggingAuditLog.new(Bandiera.logger)
+      audit_log = LoggingAuditLog.new
       set :feature_service, CachingFeatureService.new(FeatureService.new(audit_log),
         cache_size: ENV['CACHE_SIZE']&.to_i,
         cache_ttl: ENV['CACHE_TTL']&.to_i)

--- a/lib/bandiera/web_app_base.rb
+++ b/lib/bandiera/web_app_base.rb
@@ -12,10 +12,10 @@ module Bandiera
       enable :raise_errors if ENV['AIRBRAKE_API_KEY'] && ENV['AIRBRAKE_PROJECT_ID']
 
       audit_log = if ENV['RECORD_AUDIT_RECORDS'] && ENV['RECORD_AUDIT_RECORDS'].downcase == 'true'
-        LoggingAuditLog.new(recording = record_audit_records)
-      else
-        BlackholeAuditLog.new
-      end
+                    LoggingAuditLog.new(recording = record_audit_records)
+                  else
+                    BlackholeAuditLog.new
+                  end
 
       set :feature_service, CachingFeatureService.new(FeatureService.new(audit_log),
         cache_size: ENV['CACHE_SIZE']&.to_i,

--- a/lib/bandiera/web_app_base.rb
+++ b/lib/bandiera/web_app_base.rb
@@ -11,7 +11,12 @@ module Bandiera
       enable :logging
       enable :raise_errors if ENV['AIRBRAKE_API_KEY'] && ENV['AIRBRAKE_PROJECT_ID']
 
-      audit_log = LoggingAuditLog.new
+      audit_log = if ENV['RECORD_AUDIT_RECORDS'] && ENV['RECORD_AUDIT_RECORDS'].downcase == 'true'
+        LoggingAuditLog.new(recording = record_audit_records)
+      else
+        BlackholeAuditLog.new
+      end
+
       set :feature_service, CachingFeatureService.new(FeatureService.new(audit_log),
         cache_size: ENV['CACHE_SIZE']&.to_i,
         cache_ttl: ENV['CACHE_TTL']&.to_i)

--- a/spec/lib/bandiera/db_spec.rb
+++ b/spec/lib/bandiera/db_spec.rb
@@ -25,6 +25,24 @@ RSpec.describe Bandiera::Db do
     end
   end
 
+  describe 'the audit records table' do
+    it 'should be present' do
+      expect(subject.tables).to include(:audit_records)
+    end
+
+    it 'should be empty' do
+      expect(subject[:audit_records]).to be_empty
+    end
+
+    it 'should allow us to enter data' do
+      subject[:audit_records] <<
+        { timestamp: Time.now, user: 'test1', action: 'add', object: 'feature', params: 'name: feature1' }
+      subject[:audit_records] <<
+        { timestamp: Time.now, user: 'test2', action: 'delete', object: 'feature', params: 'name: feature1' }
+      expect(subject[:audit_records].count).to eq(2)
+    end
+  end
+
   describe '#ready?' do
     context 'when the database is up and ready' do
       it 'returns true' do

--- a/spec/lib/bandiera/logging_audit_log_spec.rb
+++ b/spec/lib/bandiera/logging_audit_log_spec.rb
@@ -1,33 +1,62 @@
 require 'spec_helper'
 
 RSpec.describe Bandiera::LoggingAuditLog do
-  let(:logger) { instance_double('Logger') }
+  let(:db) { Bandiera::Db.connect }
   let(:audit_context) { Bandiera::AnonymousAuditContext.new }
-  subject { Bandiera::LoggingAuditLog.new(logger) }
+  subject { Bandiera::LoggingAuditLog.new(db) }
 
   it_behaves_like 'an audit log'
 
   describe '#record' do
-    it 'records the audit message to the logger' do
-      expect(logger).to receive(:log).with('AUDIT [<anonymous>] add foodstuff (name: burger)')
+    it 'records the audit message to the audit log' do
+      expect(db[:audit_records]).to be_empty
 
       subject.record(audit_context, :add, :foodstuff, name: 'burger')
+
+      audit_record = db[:audit_records].first
+      expect(audit_record).to_not be_nil
+      expect(audit_record[:user]).to eq('<anonymous>')
+      expect(audit_record[:action]).to eq('add')
+      expect(audit_record[:object]).to eq('foodstuff')
+      expect(JSON.parse(audit_record[:params]).symbolize_keys).to eq({ name: 'burger' })
+    end
+
+    it 'sets the timestamp to the current time' do
+      expect(db[:audit_records]).to be_empty
+
+      start_time = Time.now
+      subject.record(audit_context, :add, :foodstuff, name: 'burger')
+      end_time = Time.now
+
+      audit_record = db[:audit_records].first
+      expect(audit_record).to_not be_nil
+      expect(audit_record[:timestamp]).to be_between(start_time, end_time)
     end
 
     it 'handles no parameters' do
-      expect(logger).to receive(:log).with('AUDIT [<anonymous>] eat cake')
+      expect(db[:audit_records]).to be_empty
 
-      subject.record(audit_context, :eat, :cake)
+      subject.record(audit_context, :add, :foodstuff)
+
+      audit_record = db[:audit_records].first
+      expect(audit_record).to_not be_nil
+      expect(audit_record[:params]).to be_nil
     end
 
     it 'handles multiple parameters' do
-      expect(logger).to receive(:log).with('AUDIT [<anonymous>] add foodstuff (name: burger, type: rare)')
+      expect(db[:audit_records]).to be_empty
 
       subject.record(audit_context, :add, :foodstuff, name: 'burger', type: 'rare')
+
+      audit_record = db[:audit_records].first
+      expect(audit_record).to_not be_nil
+      expect(JSON.parse(audit_record[:params]).symbolize_keys).to eq({ name: 'burger', type: 'rare' })
     end
 
     it 'does not propagate exceptions' do
-      expect(logger).to receive(:log).and_throw RuntimeError.new('This should not propagate')
+      audit_record = instance_double('Bandiera::AuditRecord')
+      expect(Bandiera::AuditRecord).to receive(:new).and_return(audit_record)
+      expect(audit_record).to receive(:save).and_throw RuntimeError.new('This should not propagate')
 
       subject.record(audit_context, :add, :foodstuff, name: 'burger')
     end

--- a/spec/lib/bandiera/logging_audit_log_spec.rb
+++ b/spec/lib/bandiera/logging_audit_log_spec.rb
@@ -23,14 +23,15 @@ RSpec.describe Bandiera::LoggingAuditLog do
 
     it 'sets the timestamp to the current time' do
       expect(db[:audit_records]).to be_empty
+      expected_time = Time.local(2017, 1, 1, 12, 0, 0)
 
-      start_time = Time.now
-      subject.record(audit_context, :add, :foodstuff, name: 'burger')
-      end_time = Time.now
+      Timecop.freeze(expected_time) do
+        subject.record(audit_context, :add, :foodstuff, name: 'burger')
+      end
 
       audit_record = db[:audit_records].first
       expect(audit_record).to_not be_nil
-      expect(audit_record[:timestamp]).to be_between(start_time, end_time)
+      expect(audit_record[:timestamp]).to eq(expected_time)
     end
 
     it 'handles no parameters' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -33,6 +33,7 @@ RSpec.configure do |config|
   config.after(:each) do
     DB[:features].delete
     DB[:groups].delete
+    DB[:audit_records].delete
   end
 
   config.disable_monkey_patching!


### PR DESCRIPTION
This changes the audit log to write to a database table.

There's an outstanding question as to whether we want an env var to allow this functionality to be disabled. As per the nature of audit logs, this table will grow (slowly, I hope) forever, which may not be desirable in some environments.

@ben-jones-springer-nature appreciate you're not a Rubyist, but I've added you as a reviewer as your team is the closest thing our internal Bandiera has to an owner, hence it's probably worth keeping you in the loop on upstream changes 😄 