### PR TITLE
Updating Nokogiri dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,8 @@ gem 'airbrake', require: false
 gem 'statsd-ruby', require: false
 gem 'rack-cors'
 
+gem 'nokogiri', '~> 1.8.2'
+
 group :development do
   gem 'shotgun'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -200,6 +200,7 @@ DEPENDENCIES
   lru_redux
   macmillan-utils
   mysql2
+  nokogiri (~> 1.8.2)
   pg
   poltergeist
   pry


### PR DESCRIPTION
GitHub's security vulnerability recommendations detected a known vulnerability in Nokogiri and recommended pinning the version as I have done. This should address CVE-2017-18258.