### PR TITLE
GDPR Logging

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -33,7 +33,8 @@ end
 require 'macmillan/utils/statsd_middleware'
 use Macmillan::Utils::StatsdMiddleware, client: Bandiera.statsd
 
-use Rack::CommonLogger, Bandiera.logger
+require 'rack/not_so_common_logger'
+use Rack::NotSoCommonLogger, Bandiera.logger
 use Airbrake::Rack::Middleware if ENV['AIRBRAKE_API_KEY'] && ENV['AIRBRAKE_PROJECT_ID']
 
 run Rack::URLMap.new(

--- a/lib/bandiera/web_app_base.rb
+++ b/lib/bandiera/web_app_base.rb
@@ -8,7 +8,6 @@ module Bandiera
     include Macmillan::Utils::StatsdControllerHelper
 
     configure do
-      enable :logging
       enable :raise_errors if ENV['AIRBRAKE_API_KEY'] && ENV['AIRBRAKE_PROJECT_ID']
 
       audit_log = if ENV['RECORD_AUDIT_RECORDS'] && ENV['RECORD_AUDIT_RECORDS'].downcase == 'true'

--- a/lib/rack/not_so_common_logger.rb
+++ b/lib/rack/not_so_common_logger.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+require 'rack/body_proxy'
+
+module Rack
+  # Rack::NotSoCommonLogger forwards every request to the given +app+, and
+  # logs a line in something similar to the
+  # {Apache common log format}[http://httpd.apache.org/docs/1.3/logs.html#common]
+  # to the +logger+.  This formatter just ensures that user identifiable
+  # information like ip addresses and identities are not logged.
+  #
+  # Rack::CommonLogger string:
+  #   127.0.0.1 - - [15/May/2018:13:15:29 +0100] "GET / HTTP/1.1" 404 510 0.1061
+  #
+  # Rack::NotSoCommonLogger string:
+  #   [15/May/2018:13:15:29 +0100] "GET / HTTP/1.1" 404 510 0.1061
+  #
+  # This ensures we don't log ip addresses and user identities if we're using
+  # basic auth
+  #
+  # If +logger+ is nil, NotSoCommonLogger will fall back +rack.errors+, which is
+  # an instance of Rack::NullLogger.
+  #
+  # +logger+ can be any class, including the standard library Logger, and is
+  # expected to have either +write+ or +<<+ method, which accepts the CommonLogger::FORMAT.
+  # According to the SPEC, the error stream must also respond to +puts+
+  # (which takes a single argument that responds to +to_s+), and +flush+
+  # (which is called without arguments in order to make the error appear for
+  # sure)
+  class NotSoCommonLogger
+    FORMAT = [
+      %([%<timestamp>s]),
+      %("%<request_method>s %<path>s%<query_string>s %<http_version>s"),
+      %(%<http_status>d),
+      %(%<content_length>s),
+      %(%<duration>0.4f),
+      "\n"
+    ].join(' ')
+
+    def initialize(app, logger = nil)
+      @app = app
+      @logger = logger
+    end
+
+    def call(env)
+      began_at = Utils.clock_time
+      status, header, body = @app.call(env)
+      header = Utils::HeaderHash.new(header)
+      body = BodyProxy.new(body) { log(env, status, header, began_at) }
+      [status, header, body]
+    end
+
+    private
+
+    def log(env, status, header, began_at)
+      msg    = log_message(env, status, header, began_at)
+      logger = @logger || env[RACK_ERRORS]
+      # Standard library logger doesn't support write but it supports << which actually
+      # calls to write on the log device without formatting
+      if logger.respond_to?(:write)
+        logger.write(msg)
+      else
+        logger << msg
+      end
+    end
+
+    def log_message(env, status, header, began_at)
+      format(
+        FORMAT,
+        timestamp:      log_time,
+        request_method: env[REQUEST_METHOD],
+        path:           env[PATH_INFO],
+        query_string:   query_string(env),
+        http_version:   env[HTTP_VERSION],
+        http_status:    status.to_s[0..3],
+        content_length: extract_content_length(header),
+        duration:       Utils.clock_time - began_at
+      )
+    end
+
+    def query_string(env)
+      env[QUERY_STRING].empty? ? '' : "?#{env[QUERY_STRING]}"
+    end
+
+    def log_time
+      Time.now.strftime('%d/%b/%Y:%H:%M:%S %z')
+    end
+
+    def extract_content_length(headers)
+      (value = headers[CONTENT_LENGTH]) || (return '-')
+      value.to_s == '0' ? '-' : value
+    end
+  end
+end

--- a/lib/rack/not_so_common_logger.rb
+++ b/lib/rack/not_so_common_logger.rb
@@ -79,7 +79,15 @@ module Rack
     end
 
     def query_string(env)
-      env[QUERY_STRING].empty? ? '' : "?#{env[QUERY_STRING]}"
+      return '' if env[QUERY_STRING].empty?
+
+      params = Rack::Utils.parse_nested_query(env[QUERY_STRING])
+
+      if ENV['SHOW_USER_GROUP_IN_LOGS'] != 'true' && params['user_group']
+        params['user_group'] = 'XXXXX'
+      end
+
+      "?#{Rack::Utils.build_nested_query(params)}"
     end
 
     def log_time

--- a/spec/lib/rack/not_so_common_logger_spec.rb
+++ b/spec/lib/rack/not_so_common_logger_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require 'rack/not_so_common_logger'
+require 'rack/lint'
+require 'rack/mock'
+require 'timecop'
+
+require 'logger'
+
+RSpec.describe Rack::NotSoCommonLogger do
+  obj    = 'foobar'
+  length = obj.size
+
+  app = Rack::Lint.new lambda { |_env|
+    [200, { 'Content-Type' => 'text/html', 'Content-Length' => length.to_s }, [obj]]
+  }
+
+  app_without_length = Rack::Lint.new lambda { |_env|
+    [200, { 'Content-Type' => 'text/html' }, []]
+  }
+
+  app_with_zero_length = Rack::Lint.new lambda { |_env|
+    [200, { 'Content-Type' => 'text/html', 'Content-Length' => '0' }, []]
+  }
+
+  it 'logs to rack.errors by default' do
+    res = Rack::MockRequest.new(described_class.new(app)).get('/')
+
+    expect(res.errors).to_not be_empty
+    expect(res.errors).to match(/"GET \/ " 200 #{length} /)
+  end
+
+  it 'logs to anything with +write+' do
+    log = StringIO.new
+    Rack::MockRequest.new(described_class.new(app, log)).get('/')
+
+    expect(log.string).to match(/"GET \/ " 200 #{length} /)
+  end
+
+  it 'works with standartd library logger' do
+    logdev = StringIO.new
+    log = Logger.new(logdev)
+    Rack::MockRequest.new(described_class.new(app, log)).get('/')
+
+    expect(logdev.string).to match(/"GET \/ " 200 #{length} /)
+  end
+
+  it 'logs - content length if header is missing' do
+    res = Rack::MockRequest.new(described_class.new(app_without_length)).get('/')
+
+    expect(res.errors).to_not be_empty
+    expect(res.errors).to match(/"GET \/ " 200 - /)
+  end
+
+  it 'logs - content length if header is zero' do
+    res = Rack::MockRequest.new(described_class.new(app_with_zero_length)).get('/')
+
+    expect(res.errors).to_not be_empty
+    expect(res.errors).to match(/"GET \/ " 200 - /)
+  end
+
+  it 'logs in almost common log format' do
+    log = StringIO.new
+    Timecop.freeze(Time.at(0)) do
+      Rack::MockRequest.new(described_class.new(app, log)).get('/')
+    end
+
+    md = /\[([^\]]+)\] "(\w+) \/ " (\d{3}) \d+ ([\d\.]+)/.match(log.string)
+
+    expect(md).to_not be_nil
+    time, method, status, duration = *md.captures
+    expect(time).to eq Time.at(0).strftime('%d/%b/%Y:%H:%M:%S %z')
+    expect(method).to eq 'GET'
+    expect(status).to eq '200'
+    expect((0..1)).to include duration.to_f
+  end
+end

--- a/spec/lib/rack/not_so_common_logger_spec.rb
+++ b/spec/lib/rack/not_so_common_logger_spec.rb
@@ -27,14 +27,14 @@ RSpec.describe Rack::NotSoCommonLogger do
     res = Rack::MockRequest.new(described_class.new(app)).get('/')
 
     expect(res.errors).to_not be_empty
-    expect(res.errors).to match(/"GET \/ " 200 #{length} /)
+    expect(res.errors).to match(%r{"GET \/ " 200 #{length} })
   end
 
   it 'logs to anything with +write+' do
     log = StringIO.new
     Rack::MockRequest.new(described_class.new(app, log)).get('/')
 
-    expect(log.string).to match(/"GET \/ " 200 #{length} /)
+    expect(log.string).to match(%r{"GET \/ " 200 #{length} })
   end
 
   it 'works with standartd library logger' do
@@ -42,21 +42,21 @@ RSpec.describe Rack::NotSoCommonLogger do
     log = Logger.new(logdev)
     Rack::MockRequest.new(described_class.new(app, log)).get('/')
 
-    expect(logdev.string).to match(/"GET \/ " 200 #{length} /)
+    expect(logdev.string).to match(%r{"GET \/ " 200 #{length} })
   end
 
   it 'logs - content length if header is missing' do
     res = Rack::MockRequest.new(described_class.new(app_without_length)).get('/')
 
     expect(res.errors).to_not be_empty
-    expect(res.errors).to match(/"GET \/ " 200 - /)
+    expect(res.errors).to match(%r{"GET \/ " 200 - })
   end
 
   it 'logs - content length if header is zero' do
     res = Rack::MockRequest.new(described_class.new(app_with_zero_length)).get('/')
 
     expect(res.errors).to_not be_empty
-    expect(res.errors).to match(/"GET \/ " 200 - /)
+    expect(res.errors).to match(%r{"GET \/ " 200 - })
   end
 
   it 'logs in almost common log format' do
@@ -65,7 +65,7 @@ RSpec.describe Rack::NotSoCommonLogger do
       Rack::MockRequest.new(described_class.new(app, log)).get('/')
     end
 
-    md = /\[([^\]]+)\] "(\w+) \/ " (\d{3}) \d+ ([\d\.]+)/.match(log.string)
+    md = %r{\[([^\]]+)\] "(\w+) \/ " (\d{3}) \d+ ([\d\.]+)}.match(log.string)
 
     expect(md).to_not be_nil
     time, method, status, duration = *md.captures
@@ -73,5 +73,33 @@ RSpec.describe Rack::NotSoCommonLogger do
     expect(method).to eq 'GET'
     expect(status).to eq '200'
     expect((0..1)).to include duration.to_f
+  end
+
+  context 'when the ENV variable "SHOW_USER_GROUP_IN_LOGS"' do
+    let(:log) { StringIO.new }
+
+    context 'is set to "true"' do
+      before do
+        ENV['SHOW_USER_GROUP_IN_LOGS'] = 'true'
+      end
+
+      it 'it does not strip out the "user_group" param' do
+        Rack::MockRequest.new(described_class.new(app, log)).get('/?user_group=darth%40vader.net')
+
+        expect(log.string).to match(%r{/\?user_group=darth%40vader\.net})
+      end
+    end
+
+    context 'is not set' do
+      before do
+        ENV.delete('SHOW_USER_GROUP_IN_LOGS')
+      end
+
+      it 'it hashes out the "user_group" URL param' do
+        Rack::MockRequest.new(described_class.new(app, log)).get('/?user_group=darth%40vader.net')
+
+        expect(log.string).to match(%r{/\?user_group=XXXXX})
+      end
+    end
   end
 end


### PR DESCRIPTION
These changes update the logging in bandiera to be a little bit more compliant with the new GDPR EU legislation coming into effect on May 25th.

It removes the users IP address and userid (if using basic auth) from the log lines, and also by default suppresses the `user_group` URL param as this can often contain a users email address.

If the user desires the `user_group` to be logged in full, they will need to set the environment variable "SHOW_USER_GROUP_IN_LOGS" to "true".