### PR TITLE
Group page

### DIFF
--- a/lib/bandiera/gui.rb
+++ b/lib/bandiera/gui.rb
@@ -30,10 +30,7 @@ module Bandiera
     end
 
     def _get_home
-      @groups_and_features = feature_service.fetch_groups.map do |group|
-        { name: group.name, features: feature_service.fetch_group_features(group.name) }
-      end
-
+      @groups_and_features = feature_service.fetch_groups
       erb :index
     end
 
@@ -45,6 +42,11 @@ module Bandiera
 
     def _get_new_group
       erb :new_group
+    end
+
+    get '/groups/:group_name' do |group_name|
+      @group = feature_service.find_group(group_name)
+      erb :group
     end
 
     post '/create/group' do

--- a/lib/bandiera/gui.rb
+++ b/lib/bandiera/gui.rb
@@ -66,12 +66,13 @@ module Bandiera
     # Features
 
     get '/new/feature' do
-      _get_new_feature
-    end
-
-    def _get_new_feature
-      @groups = feature_service.fetch_groups
-
+      group_name = params[:group]
+      if group_name
+        @group = feature_service.find_group(group_name)
+        @back_to_group = true
+      else
+        @groups = feature_service.fetch_groups
+      end
       erb :new_feature
     end
 
@@ -81,11 +82,17 @@ module Bandiera
 
     def _post_create_feature
       feature = process_v2_feature_params(params[:feature])
+      back_to_group = params[:back_to_group] == 'true'
+      on_err_url = back_to_group ? "/new/feature?group=#{feature[:group]}": '/new/feature'
 
-      with_valid_feature_params(feature, '/new/feature') do
+      with_valid_feature_params(feature, on_err_url) do
         feature_service.add_feature(audit_context, feature)
         flash[:success] = 'Feature created.'
-        redirect '/'
+        if back_to_group
+          redirect "/groups/#{feature[:group].name}"
+        else
+          redirect '/'
+        end
       end
     end
 

--- a/lib/bandiera/gui.rb
+++ b/lib/bandiera/gui.rb
@@ -83,7 +83,7 @@ module Bandiera
     def _post_create_feature
       feature = process_v2_feature_params(params[:feature])
       back_to_group = params[:back_to_group] == 'true'
-      on_err_url = back_to_group ? "/new/feature?group=#{feature[:group]}": '/new/feature'
+      on_err_url = back_to_group ? "/new/feature?group=#{feature[:group]}" : '/new/feature'
 
       with_valid_feature_params(feature, on_err_url) do
         feature_service.add_feature(audit_context, feature)

--- a/lib/bandiera/gui/views/_feature_form.erb
+++ b/lib/bandiera/gui/views/_feature_form.erb
@@ -1,7 +1,7 @@
 <%
   @feature ||= Bandiera::Feature.new(
     name:         '',
-    group:        nil,
+    group:        defined?(group).nil? ? nil : group,
     description:  '',
     active:       false,
     user_groups:  { list: [], regex: '' }
@@ -11,8 +11,8 @@
 <form role="form" action="<%= action %>" method="post">
   <div class="form-group">
     <label for="feature[group]">Group</label>
-    <% if method == :update %>
-      <input type="text" class="form-control" id="feature_group" name="feature[group]" value="<%= @feature.group.name %>" <% if method == :update %>readonly<% end %>/>
+    <% if @feature.group %>
+      <input type="text" class="form-control" id="feature_group" name="feature[group]" value="<%= @feature.group.name %>" readonly/>
     <% else %>
       <select class="form-control" id="feature_group" name="feature[group]">
         <option></option>
@@ -129,6 +129,7 @@
 
   <input type="hidden" name="feature[previous_group]" value="<%= @feature.group ? @feature.group.name : nil %>" />
   <input type="hidden" name="feature[previous_name]" value="<%= @feature.name %>" />
+  <input type="hidden" name="back_to_group" value="<%= defined?(back_to_group) && back_to_group == true %>" />
 
   <button type="submit" class="btn btn-primary"><%= method.to_s.capitalize %></button>
 </form>

--- a/lib/bandiera/gui/views/_feature_form.erb
+++ b/lib/bandiera/gui/views/_feature_form.erb
@@ -1,7 +1,7 @@
 <%
   @feature ||= Bandiera::Feature.new(
     name:         '',
-    group:        defined?(group).nil? ? nil : group,
+    group:        defined?(group) ? group : nil,
     description:  '',
     active:       false,
     user_groups:  { list: [], regex: '' }

--- a/lib/bandiera/gui/views/_features_table.erb
+++ b/lib/bandiera/gui/views/_features_table.erb
@@ -1,0 +1,41 @@
+<table class="table table-striped table-hover">
+  <thead>
+  <tr>
+    <th style="text-align:center">Active?</th>
+    <th style="text-align:center">User Groups?</th>
+    <th style="text-align:center">User %</th>
+    <th style="text-align:center">Date Range</th>
+    <th width="20%">Name</th>
+    <th width="30%">Description</th>
+    <th></th>
+  </tr>
+  </thead>
+  <tbody>
+  <% group.features.each do |feature| %>
+    <tr class="bandiera-feature">
+      <td class="feature-toggle" data-group="<%= group[:name] %>" data-feature="<%= feature.name %>" data-description="<%= feature.description %>" data-active="<%= feature.active? %>"><%= feature.active? %></td>
+      <td style="text-align:center">
+        <% if feature.user_groups_configured? %>
+          <span class="fa fa-check"></span>
+        <% end %>
+      </td>
+      <td style="text-align:center">
+        <% if feature.percentage %>
+          <span class="fa fa-check"></span>
+        <% end %>
+      </td>
+      <td style="text-align:center">
+        <% if feature.start_time && feature.end_time %>
+          <span class="fa fa-check"></span>
+        <% end %>
+      </td>
+      <td><%= feature.name %></td>
+      <td><%= feature.description %></td>
+      <td style="text-align:right">
+        <a class="btn btn-warning btn-sm bandiera-edit-feature" href="/groups/<%= group[:name] %>/features/<%= feature.name %>/edit"><i class="fa fa-edit"></i> edit</a>
+        <a class="btn btn-danger btn-sm bandiera-delete-feature" href="/groups/<%= group[:name] %>/features/<%= feature.name %>/delete" data-method="delete"><i class="fa fa-trash-o"></i> delete</a>
+      </td>
+    </tr>
+  <% end %>
+  </tbody>
+</table>

--- a/lib/bandiera/gui/views/group.erb
+++ b/lib/bandiera/gui/views/group.erb
@@ -1,0 +1,24 @@
+<div class="row" style="padding-bottom:15px">
+  <div class="col-md-12 pull-right">
+    <div class="pull-right">
+      <a class="btn btn-default" href="/new/feature" role="button"><span class="fa fa-plus"></span> add a feature</a>
+    </div>
+  </div>
+</div>
+
+<div class="row">
+  <div class="col-md-12">
+    <div class="panel panel-info bandiera-feature-group">
+      <div class="panel-heading">
+        <h3 class="panel-title"><%= @group[:name] %></h3>
+      </div>
+      <div class="panel-body">
+        <% if @group.features.empty? %>
+          <p class="no-features">There are no features setup...</p>
+        <% else %>
+          <%== partial :_features_table, { group: @group } %>
+        <% end %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/lib/bandiera/gui/views/group.erb
+++ b/lib/bandiera/gui/views/group.erb
@@ -1,7 +1,7 @@
 <div class="row" style="padding-bottom:15px">
   <div class="col-md-12 pull-right">
     <div class="pull-right">
-      <a class="btn btn-default" href="/new/feature" role="button"><span class="fa fa-plus"></span> add a feature</a>
+      <a class="btn btn-default" href="/new/feature?group=<%= @group[:name] %>" role="button"><span class="fa fa-plus"></span> add a feature</a>
     </div>
   </div>
 </div>

--- a/lib/bandiera/gui/views/index.erb
+++ b/lib/bandiera/gui/views/index.erb
@@ -19,53 +19,13 @@
       <% @groups_and_features.each do |group| %>
         <div class="panel panel-info bandiera-feature-group">
           <div class="panel-heading">
-            <h3 class="panel-title"><%= group[:name] %></h3>
+            <h3 class="panel-title"><a href="/groups/<%= group[:name] %>"><%= group[:name] %></a></h3>
           </div>
           <div class="panel-body">
-            <% if group[:features].empty? %>
+            <% if group.features.empty? %>
               <p class="no-features">There are no features setup...</p>
             <% else %>
-              <table class="table table-striped table-hover">
-                <thead>
-                  <tr>
-                    <th style="text-align:center">Active?</th>
-                    <th style="text-align:center">User Groups?</th>
-                    <th style="text-align:center">User %</th>
-                    <th style="text-align:center">Date Range</th>
-                    <th width="20%">Name</th>
-                    <th width="30%">Description</th>
-                    <th></th>
-                  </tr>
-                </thead>
-                <tbody>
-                  <% group[:features].each do |feature| %>
-                    <tr class="bandiera-feature">
-                      <td class="feature-toggle" data-group="<%= group[:name] %>" data-feature="<%= feature.name %>" data-description="<%= feature.description %>" data-active="<%= feature.active? %>"><%= feature.active? %></td>
-                      <td style="text-align:center">
-                        <% if feature.user_groups_configured? %>
-                          <span class="fa fa-check"></span>
-                        <% end %>
-                      </td>
-                      <td style="text-align:center">
-                        <% if feature.percentage %>
-                          <span class="fa fa-check"></span>
-                        <% end %>
-                      </td>
-                      <td style="text-align:center">
-                        <% if feature.start_time && feature.end_time %>
-                            <span class="fa fa-check"></span>
-                        <% end %>
-                      </td>
-                      <td><%= feature.name %></td>
-                      <td><%= feature.description %></td>
-                      <td style="text-align:right">
-                        <a class="btn btn-warning btn-sm bandiera-edit-feature" href="/groups/<%= group[:name] %>/features/<%= feature.name %>/edit"><i class="fa fa-edit"></i> edit</a>
-                        <a class="btn btn-danger btn-sm bandiera-delete-feature" href="/groups/<%= group[:name] %>/features/<%= feature.name %>/delete" data-method="delete"><i class="fa fa-trash-o"></i> delete</a>
-                      </td>
-                    </tr>
-                  <% end %>
-                </tbody>
-              </table>
+              <%== partial :_features_table, { group: group } %>
             <% end %>
           </div>
         </div>

--- a/lib/bandiera/gui/views/new_feature.erb
+++ b/lib/bandiera/gui/views/new_feature.erb
@@ -2,10 +2,12 @@
 
 <h2>Create a New Feature</h2>
 
-<div class="container" style="padding-bottom:15px">
-  <div class="pull-right">
-    <a class="btn btn-default" href="/new/group" role="button"><span class="fa fa-plus"></span> add a group</a>
+<% if @group.nil? %>
+  <div class="container" style="padding-bottom:15px">
+    <div class="pull-right">
+      <a class="btn btn-default" href="/new/group" role="button"><span class="fa fa-plus"></span> add a group</a>
+    </div>
   </div>
-</div>
+<% end %>
 
-<%== partial :_feature_form, { action: '/create/feature', method: :create } %>
+<%== partial :_feature_form, { action: '/create/feature', method: :create, group: @group, back_to_group: @back_to_group } %>

--- a/spec/lib/bandiera/gui_spec.rb
+++ b/spec/lib/bandiera/gui_spec.rb
@@ -198,6 +198,7 @@ RSpec.describe Bandiera::GUI do
 
         check_success_flash('Feature created')
         expect(@service.fetch_feature('pubserv', 'TEST-FEATURE')).to be_an_instance_of(Bandiera::Feature)
+        expect(page).to have_current_path('/')
       end
 
       context 'for a feature flag configured for user_groups' do
@@ -347,6 +348,41 @@ RSpec.describe Bandiera::GUI do
         end
 
         check_error_flash('You must enter an end time that is after your start time')
+      end
+    end
+  end
+
+  describe 'adding a new feature flag with group query param' do
+    before do
+      visit('/new/feature?group=shunter')
+    end
+
+    context 'with valid details' do
+      it 'adds a new feature flag and returns to group page' do
+        within('form') do
+          fill_in 'feature_name', with: 'TEST-FEATURE'
+          fill_in 'feature_description', with: 'This is a test feature.'
+          choose 'feature_active_true'
+          click_button 'Create'
+        end
+
+        check_success_flash('Feature created')
+        expect(@service.fetch_feature('shunter', 'TEST-FEATURE')).to be_an_instance_of(Bandiera::Feature)
+        expect(page).to have_current_path('/groups/shunter')
+      end
+    end
+
+    context 'with a blank feature flag name' do
+      it 'shows validation errors' do
+        within('form') do
+          fill_in 'feature_name', with: ''
+          fill_in 'feature_description', with: 'This is a test feature.'
+          choose 'feature_active_true'
+          click_button 'Create'
+        end
+
+        check_error_flash('You must enter a feature name')
+        expect(page).to have_current_path('/new/feature?group=shunter')
       end
     end
   end

--- a/spec/lib/bandiera/gui_spec.rb
+++ b/spec/lib/bandiera/gui_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe Bandiera::GUI do
     it 'shows all feature flags organised by group' do
       visit('/')
 
-      groups = get_groups_with_features()
+      groups = get_groups_with_features
 
       expect(groups['nofeatures_group']).to match_array([])
       expect(groups['pubserv']).to match_array(%w[show_subjects show_search])
@@ -110,7 +110,7 @@ RSpec.describe Bandiera::GUI do
       context 'and has features' do
         it 'shows features of group' do
           visit('/groups/pubserv')
-          groups = get_groups_with_features()
+          groups = get_groups_with_features
 
           expect(groups['pubserv']).to match_array(%w[show_subjects show_search])
           expect(groups.size).to eq(1)
@@ -120,7 +120,7 @@ RSpec.describe Bandiera::GUI do
       context 'and doesnt have features' do
         it 'no features are showed' do
           visit('/groups/nofeatures_group')
-          groups = get_groups_with_features()
+          groups = get_groups_with_features
 
           expect(groups.size).to eq(1)
           expect(groups['nofeatures_group']).to match_array([])
@@ -431,7 +431,7 @@ RSpec.describe Bandiera::GUI do
     expect(page.find('.alert-danger')).to have_content(expected_text)
   end
 
-  def get_groups_with_features()
+  def get_groups_with_features
     groups = {}
 
     all('.bandiera-feature-group').each do |div|


### PR DESCRIPTION
addressing https://github.com/springernature/bandiera/issues/72

- group page: `/groups/xyz` only shows features of group `xyz`
- homepage: group names are clickable and navigate to the group page
- adding a feature from group page will:
  - preselect group (non-editable, like the edit page)
  - go back to group page after creation
- refactored the features table to its own file so it can be used as partial for both group/home pages
- tests + tested manually

didn't do and would be nice to have:
- also edit/delete from group page should return to group page
- correct breadcrumbs
