### PR TITLE
Log to Stackdriver JSON

### DIFF
--- a/lib/bandiera.rb
+++ b/lib/bandiera.rb
@@ -1,7 +1,8 @@
-require 'json'
 require 'dotenv'
+require 'json'
+require 'logger'
 require 'sequel'
-require 'macmillan/utils/logger'
+require 'syslog-logger'
 require_relative 'hash'
 
 GC::Profiler.enable
@@ -30,13 +31,13 @@ module Bandiera
     end
 
     def logger
-      @logger ||= begin
-                    if ENV['LOG_TO_STDOUT']
-                      Macmillan::Utils::Logger::Factory.build_logger
-                    else
-                      Macmillan::Utils::Logger::Factory.build_logger(:syslog, tag: 'bandiera')
-                    end
-                  end
+      return @logger if @logger
+
+      @logger = if ENV['LOG_TO_STDOUT']
+                  Logger.new($stdout)
+                else
+                  Logger::Syslog.new('bandiera', Syslog::LOG_LOCAL0)
+                end
     end
     attr_writer :logger
 

--- a/lib/bandiera.rb
+++ b/lib/bandiera.rb
@@ -38,6 +38,13 @@ module Bandiera
                 else
                   Logger::Syslog.new('bandiera', Syslog::LOG_LOCAL0)
                 end
+
+      if ENV['STACKDRIVER_JSON_LOGGER']
+        require 'logger/stackdriver_json_formatter'
+        @logger.formatter = Logger::StackdriverJsonFormatter.new
+      end
+
+      @logger
     end
     attr_writer :logger
 

--- a/lib/logger/stackdriver_json_formatter.rb
+++ b/lib/logger/stackdriver_json_formatter.rb
@@ -1,0 +1,23 @@
+require 'json'
+
+class Logger
+  class StackdriverJsonFormatter < Logger::Formatter
+    def call(severity, _time, _progname, msg)
+      json = { severity: severity, message: msg2str(msg) }
+      "#{JSON.generate(json)}\n"
+    end
+
+    protected
+
+    def msg2str(msg)
+      case msg
+      when String
+        msg
+      when Exception
+        "#{msg.message} (#{msg.class})\n#{(msg.backtrace || []).join("\n")}"
+      else
+        msg.inspect
+      end
+    end
+  end
+end

--- a/spec/lib/logger/stackdriver_json_formatter_spec.rb
+++ b/spec/lib/logger/stackdriver_json_formatter_spec.rb
@@ -1,0 +1,74 @@
+require 'spec_helper'
+require 'logger/stackdriver_json_formatter'
+
+RSpec.describe Logger::StackdriverJsonFormatter do
+  let(:msg)    { 'testing' }
+  let(:target) { File.open('/dev/null', 'w+') }
+
+  subject { described_class.new }
+
+  let(:logger) do
+    log = Logger.new(target)
+    log.formatter = subject
+    log
+  end
+
+  describe '#call' do
+    it 'is called by the logger object' do
+      expect(target).to receive(:write).once
+      expect(subject).to receive(:call).once
+      logger.info('this is a test')
+    end
+
+    describe 'the logging level' do
+      it 'is passed into the severity key in the JSON message' do
+        [:info, :warn, :debug].each do |severity|
+          expect(target)
+            .to receive(:write)
+            .with(%({"severity":"#{severity.to_s.upcase}","message":"#{msg}"}\n))
+            .once
+
+          logger.public_send(severity, msg)
+        end
+      end
+    end
+
+    context 'when the log message is a string' do
+      it 'logs the string in the JSON message' do
+        expect(target)
+          .to receive(:write)
+          .with(%({"severity":"INFO","message":"#{msg}"}\n))
+          .once
+
+        logger.info(msg)
+      end
+    end
+
+    context 'when the log message is an exception' do
+      it 'returns full details of the exception' do
+        ex = StandardError.new('qwerty')
+        allow(ex).to receive(:backtrace).and_return(%w[foo bar baz])
+
+        expected = JSON.generate({
+          severity: 'INFO',
+          message: "qwerty (StandardError)\nfoo\nbar\nbaz"
+        })
+
+        expect(target)
+          .to receive(:write)
+          .with(%(#{expected}\n))
+          .once
+
+        logger.info(ex)
+      end
+    end
+
+    context 'when the log message is NOT a string or exception' do
+      it 'returns object.inspect' do
+        ex = []
+        expect(ex).to receive(:inspect).once
+        logger.info(ex)
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,7 +19,7 @@ shared_example_files = File.expand_path('shared_examples/**/*.rb', __dir__)
 Dir[shared_example_files].each(&method(:require))
 
 # Suppress logging
-Bandiera.logger = Macmillan::Utils::Logger::Factory.build_logger(:null)
+# Bandiera.logger = Logger.new('/dev/null')
 Bandiera.statsd = Macmillan::Utils::StatsdStub.new
 
 # use an in-memory sqlite database for testing

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,7 +19,7 @@ shared_example_files = File.expand_path('shared_examples/**/*.rb', __dir__)
 Dir[shared_example_files].each(&method(:require))
 
 # Suppress logging
-# Bandiera.logger = Logger.new('/dev/null')
+Bandiera.logger = Logger.new('/dev/null')
 Bandiera.statsd = Macmillan::Utils::StatsdStub.new
 
 # use an in-memory sqlite database for testing


### PR DESCRIPTION
This is a useful feature for people running bandiera on the Google Cloud
Platform.  This will present the logs as structured JSON ready for
ingesting into Stackdriver logs so there are no duplicate timestamps and
log levels making noise.