### PR TITLE
Debug logging

### DIFF
--- a/HISTORY
+++ b/HISTORY
@@ -1,22 +1,24 @@
-= 3.5.2 / 2018-07-16
+= 3.5.2 / 2018-07-17
 
-Addition of a new ENV variable `LOG_LEVEL`.  By default Bandiera will log at `DEBUG` upwards,
-if this is not your preference, you can now change this using this variable.  Accepted inputs
-are the constants in [Logger::Severity](https://ruby-doc.org/stdlib-2.5.1/libdoc/logger/rdoc/Logger/Severity.html)
+Addition of a new ENV variable `LOG_LEVEL`.  By default Bandiera will log at
+`INFO` upwards, if this is not your preference, you can now change this using
+this variable.  Accepted inputs are the constants in
+[Logger::Severity](https://ruby-doc.org/stdlib-2.5.1/libdoc/logger/rdoc/Logger/Severity.html)
 i.e. `DEBUG`, `INFO` etc.
 
-Added some DEBUG logging outputting the response from Bandiera to a v2 API request.  This
-doesn't contain any user identifying data, but can be useful for users/admins when debugging
-flag/api issues.
+Added some DEBUG logging outputting the response from Bandiera to a v2 API
+request.  This doesn't contain any user identifying data, but can be useful for
+users/admins when debugging flag/api issues.
 
 = 3.5.1 / 2018-07-13
 
-Addition of a new ENV variable `STACKDRIVER_JSON_LOGGER` - if this is present at
-runtime, the logs will be output in JSON that is suitable for being consumed by
-Google Cloud's Stackdriver logging.
+Addition of a new ENV variable `STACKDRIVER_JSON_LOGGER` - if this is present
+at runtime, the logs will be output in JSON that is suitable for being consumed
+by Google Cloud's Stackdriver logging.
 
 Addition of a new ENV variable `SENTRY_DSN` - if this is present at runtime
-errors will be reported to the configured project on [sentry.io](https://sentry.io).
+errors will be reported to the configured project on
+[sentry.io](https://sentry.io).
 
 = 3.5.0 / 2018-05-18
 
@@ -55,7 +57,8 @@ Add the ability to enable CORS headers for the v2 API (via an ENV variable)
 
 = 3.3.1 / 2017-09-21
 
-Update all dependent gems (inlcuding nokogiri security patch - https://github.com/sparklemotion/nokogiri/issues/1673)
+Update all dependent gems (inlcuding nokogiri security patch -
+https://github.com/sparklemotion/nokogiri/issues/1673)
 
 = 3.3.0 / 2017-09-18
 

--- a/HISTORY
+++ b/HISTORY
@@ -1,3 +1,14 @@
+= 3.5.2 / 2018-07-16
+
+Addition of a new ENV variable `LOG_LEVEL`.  By default Bandiera will log at `DEBUG` upwards,
+if this is not your preference, you can now change this using this variable.  Accepted inputs
+are the constants in [Logger::Severity](https://ruby-doc.org/stdlib-2.5.1/libdoc/logger/rdoc/Logger/Severity.html)
+i.e. `DEBUG`, `INFO` etc.
+
+Added some DEBUG logging outputting the response from Bandiera to a v2 API request.  This
+doesn't contain any user identifying data, but can be useful for users/admins when debugging
+flag/api issues.
+
 = 3.5.1 / 2018-07-13
 
 Addition of a new ENV variable `STACKDRIVER_JSON_LOGGER` - if this is present at

--- a/lib/bandiera.rb
+++ b/lib/bandiera.rb
@@ -44,7 +44,7 @@ module Bandiera
         @logger.formatter = Logger::StackdriverJsonFormatter.new
       end
 
-      @logger.level = Logger.const_get(ENV.fetch('LOG_LEVEL', 'DEBUG').upcase)
+      @logger.level = Logger.const_get(ENV.fetch('LOG_LEVEL', 'INFO').upcase)
 
       @logger
     end

--- a/lib/bandiera.rb
+++ b/lib/bandiera.rb
@@ -44,6 +44,8 @@ module Bandiera
         @logger.formatter = Logger::StackdriverJsonFormatter.new
       end
 
+      @logger.level = Logger.const_get(ENV.fetch('LOG_LEVEL', 'DEBUG').upcase)
+
       @logger
     end
     attr_writer :logger

--- a/lib/bandiera/api_v2.rb
+++ b/lib/bandiera/api_v2.rb
@@ -133,6 +133,8 @@ module Bandiera
       callback = params.delete('callback')
       json     = JSON.generate(data)
 
+      Bandiera.logger.debug("RESPONSE: #{json}")
+
       if callback
         content_type :js
         "#{callback}(#{json})"

--- a/lib/bandiera/version.rb
+++ b/lib/bandiera/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Bandiera
-  VERSION = '3.5.1'
+  VERSION = '3.5.2'
 end


### PR DESCRIPTION
Addition of a new ENV variable `LOG_LEVEL`.  By default Bandiera will log at `DEBUG` upwards,
if this is not your preference, you can now change this using this variable.  Accepted inputs
are the constants in [Logger::Severity](https://ruby-doc.org/stdlib-2.5.1/libdoc/logger/rdoc/Logger/Severity.html)
i.e. `DEBUG`, `INFO` etc.

Added some DEBUG logging outputting the response from Bandiera to a v2 API request.  This
doesn't contain any user identifying data, but can be useful for users/admins when debugging
flag/api issues.