### PR TITLE
Update the Dockerfile to fix Alpine SSL issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,8 @@ FROM ruby:2.4.2-alpine
 
 MAINTAINER Darren Oakley <daz.oakley@gmail.com>
 
-RUN apk add --update --no-cache build-base ruby-dev libxml2-dev libxslt-dev postgresql-dev mysql-dev openssl-dev
+RUN apk add --update --no-cache build-base ruby-dev libxml2-dev libxslt-dev postgresql-dev mysql-dev openssl openssl-dev ca-certificates && \
+  update-ca-certificates
 
 ENV APP_HOME /app
 RUN mkdir $APP_HOME
@@ -16,4 +17,4 @@ COPY . .
 
 EXPOSE 5000
 
-CMD "puma"
+CMD ["puma"]

--- a/HISTORY
+++ b/HISTORY
@@ -1,3 +1,11 @@
+= 3.5.3 / 2018-07-17
+
+Dockerfile update to include additional packages:
+ - openssl
+ - ca-certificates
+
+This solves some SSL issues on alpine based images.
+
 = 3.5.2 / 2018-07-17
 
 Addition of a new ENV variable `LOG_LEVEL`.  By default Bandiera will log at

--- a/lib/bandiera/version.rb
+++ b/lib/bandiera/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Bandiera
-  VERSION = '3.5.2'
+  VERSION = '3.5.3'
 end


### PR DESCRIPTION
This change adds the `openssl` and `ca-certificates` packages and fixes
the SSL issues that are common when you're trying to run scripts in
Alpine.