### PR TITLE
creation/update timestamps for feature model

### DIFF
--- a/db/migrations/012_add_timestamps_to_features.rb
+++ b/db/migrations/012_add_timestamps_to_features.rb
@@ -1,0 +1,8 @@
+Sequel.migration do
+  change do
+    alter_table(:features) do
+      add_column :created_at, Time, { default: nil }
+      add_column :updated_at, Time, { default: nil }
+    end
+  end
+end

--- a/lib/bandiera/feature.rb
+++ b/lib/bandiera/feature.rb
@@ -3,6 +3,7 @@ module Bandiera
     many_to_one :group
 
     plugin :serialization
+    plugin :timestamps, create: :created_at, update: :updated_at, update_on_create: true
 
     serialize_attributes :json, :user_groups
 

--- a/lib/bandiera/gui/public/site.css
+++ b/lib/bandiera/gui/public/site.css
@@ -25,3 +25,20 @@
 .bandiera-feature-group .panel-body .no-features {
   margin: 15px;
 }
+
+/*bootstarp overrides*/
+@media (min-width:768px){
+  .container {
+    width: 100%;
+  }
+}
+@media (min-width:1200px){
+  .container {
+    width: 90%;
+  }
+}
+@media (min-width:1600px){
+  .container {
+    width: 80%;
+  }
+}

--- a/lib/bandiera/gui/views/_features_table.erb
+++ b/lib/bandiera/gui/views/_features_table.erb
@@ -7,6 +7,7 @@
     <th style="text-align:center">Date Range</th>
     <th width="20%">Name</th>
     <th width="30%">Description</th>
+    <th>Updated At(UTC)</th>
     <th></th>
   </tr>
   </thead>
@@ -31,9 +32,10 @@
       </td>
       <td><%= feature.name %></td>
       <td><%= feature.description %></td>
+      <td><%= (d = (feature.updated_at || feature.created_at)) && ((d && d.utc.strftime('%F %T')) || "N/A") %></td>
       <td style="text-align:right">
-        <a class="btn btn-warning btn-sm bandiera-edit-feature" href="/groups/<%= group[:name] %>/features/<%= feature.name %>/edit"><i class="fa fa-edit"></i> edit</a>
-        <a class="btn btn-danger btn-sm bandiera-delete-feature" href="/groups/<%= group[:name] %>/features/<%= feature.name %>/delete" data-method="delete"><i class="fa fa-trash-o"></i> delete</a>
+        <a class="btn btn-warning btn-sm bandiera-edit-feature" href="/groups/<%= group[:name] %>/features/<%= feature.name %>/edit"><i class="fa fa-edit" title="edit"></i></a>
+        <a class="btn btn-danger btn-sm bandiera-delete-feature" href="/groups/<%= group[:name] %>/features/<%= feature.name %>/delete" data-method="delete"><i class="fa fa-trash-o" title="delete"></i></a>
       </td>
     </tr>
   <% end %>


### PR DESCRIPTION
- used Suquel plugin :timestamps
- added migration to add columns
- show last changed (update || create) in features table

small ui adjustments:
- remvoed delete/edit text from action buttons.
  - the icon is already clear enough
  - hovering over icon will display that text 
- played with width of table on different breakpoints to make it feel better (subjectively, to my taste)
  - bootstrap default was something like `width: ~ 1200px` for devices wider than 768px, which was losing a lot of screen real estate for wide screens :)

i didnt add any tests, because it felt like i'd be jut testing the sequel plugin.
i did however test everything locally.