### PR TITLE
Add a basic `/metrics` data page for prometheus

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ gem 'macmillan-utils'
 gem 'mysql2', platform: :ruby
 gem 'nokogiri', '~> 1.8.2'
 gem 'pg', platform: :ruby
+gem 'prometheus-client'
 gem 'puma', require: false
 gem 'rack-cors'
 gem 'rack-flash3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -102,6 +102,8 @@ GEM
       cliver (~> 0.3.1)
       websocket-driver (>= 0.2.0)
     powerpack (0.1.2)
+    prometheus-client (0.8.0)
+      quantile (~> 0.2.1)
     pry (0.11.3)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
@@ -112,6 +114,7 @@ GEM
     public_suffix (3.0.3)
     puma (3.12.0)
     puma (3.12.0-java)
+    quantile (0.2.1)
     rack (2.0.5)
     rack-cors (1.0.2)
     rack-flash3 (1.0.5)
@@ -211,6 +214,7 @@ DEPENDENCIES
   nokogiri (~> 1.8.2)
   pg
   poltergeist
+  prometheus-client
   pry
   puma
   rack-cors

--- a/config.ru
+++ b/config.ru
@@ -43,6 +43,13 @@ if ENV['RACK_CORS_ORIGINS']
   end
 end
 
+require 'rack'
+require 'prometheus/middleware/collector'
+require 'prometheus/middleware/exporter'
+use Rack::Deflater
+use Prometheus::Middleware::Collector
+use Prometheus::Middleware::Exporter
+
 require 'macmillan/utils/statsd_middleware'
 use Macmillan::Utils::StatsdMiddleware, client: Bandiera.statsd
 


### PR DESCRIPTION
This change adds in the prometheus-client gem and a default `/metrics`
endpoint for prometheus to scrape request performance data from.