### PR TITLE
Switch to use `prometheus-client-mmap`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem 'macmillan-utils'
 gem 'mysql2', platform: :ruby
 gem 'nokogiri', '~> 1.8.2'
 gem 'pg', platform: :ruby
-gem 'prometheus-client'
+gem 'prometheus-client-mmap'
 gem 'puma', require: false
 gem 'rack-cors'
 gem 'rack-flash3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -102,8 +102,7 @@ GEM
       cliver (~> 0.3.1)
       websocket-driver (>= 0.2.0)
     powerpack (0.1.2)
-    prometheus-client (0.8.0)
-      quantile (~> 0.2.1)
+    prometheus-client-mmap (0.9.5)
     pry (0.11.3)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
@@ -114,7 +113,6 @@ GEM
     public_suffix (3.0.3)
     puma (3.12.0)
     puma (3.12.0-java)
-    quantile (0.2.1)
     rack (2.0.5)
     rack-cors (1.0.2)
     rack-flash3 (1.0.5)
@@ -214,7 +212,7 @@ DEPENDENCIES
   nokogiri (~> 1.8.2)
   pg
   poltergeist
-  prometheus-client
+  prometheus-client-mmap
   pry
   puma
   rack-cors
@@ -233,4 +231,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.16.0
+   1.16.2

--- a/config.ru
+++ b/config.ru
@@ -43,12 +43,10 @@ if ENV['RACK_CORS_ORIGINS']
   end
 end
 
-require 'rack'
-require 'prometheus/middleware/collector'
-require 'prometheus/middleware/exporter'
-use Rack::Deflater
-use Prometheus::Middleware::Collector
-use Prometheus::Middleware::Exporter
+require 'prometheus/client/rack/collector'
+require 'prometheus/client/rack/exporter'
+use Prometheus::Client::Rack::Collector
+use Prometheus::Client::Rack::Exporter
 
 require 'macmillan/utils/statsd_middleware'
 use Macmillan::Utils::StatsdMiddleware, client: Bandiera.statsd


### PR DESCRIPTION
The original `prometheus-client` gem doesn't work well for multi-process
web servers.  This gives consistent data regardless of the web server
used.